### PR TITLE
Let every file remember the pen it was last drawn with

### DIFF
--- a/.agents/skills/pdf-and-drawings/SKILL.md
+++ b/.agents/skills/pdf-and-drawings/SKILL.md
@@ -249,6 +249,19 @@ locked backdrop image shapes, but the pages come from a `paper` block instead of
 canvases. Split across two files because `react-refresh/only-export-components` is relaxed for
 `src/context/**` only, so a component and a helper cannot share a file.
 
+- **The pen is PER FILE, and per open editor.** `penStyle` keys on the live `Editor` in a WeakMap,
+  not one app-wide value, because a split shows two canvases at once and each answers to its own
+  file. `canvasPen`'s `CanvasUiState` (`toolId` + `stylesForNextShape` + `penScale`) is the one shape
+  all three canvases write into their file's `ui` key — tldraw's own snapshots carry NO styles
+  (`TLSessionStateSnapshot` is camera and selection only), which is why an annotated PDF used to
+  reopen with the default pen while drawings and notebooks did not. `applyCanvasUi` must run BEFORE
+  `applyPenDefaults` (whose shape handler reads the seeded width) and before the save listeners
+  attach, or restoring a file marks it dirty. An unseeded file inherits the last width used anywhere
+  (localStorage) rather than snapping to the default.
+- **Width changes touch no tldraw store**, so the panes also `subscribePenScale` — the session
+  listener alone never sees them, and the width was only remembered if you happened to draw after.
+  `PdfAnnotateCanvas` deliberately does NOT: its save rebuilds the whole document (~150ms/page), so
+  the pen rides the next stroke's flush instead of stalling under a colour click.
 - **Width is `props.scale`, NOT the `size` style.** tldraw's thinnest, `s`, is `(2*1 + 1) = 3px`;
   handwriting on ruled paper needs less. `size` is pinned to `s`, `dash` to `solid`, and a
   `registerBeforeCreateHandler` stamps `scale` on every new shape that HAS that prop — `scale` is an

--- a/src/components/CanvasStylePanel.tsx
+++ b/src/components/CanvasStylePanel.tsx
@@ -59,7 +59,10 @@ export default function CanvasStylePanel() {
     const editor = useEditor();
     const color = useCurrentColor(editor);
     const swatches = useSwatchColors(editor);
-    const scale = useSyncExternalStore(subscribePenScale, getPenScale, getPenScale);
+    // This canvas's own width, not the app's: two files can be on screen at
+    // once in a split, each remembering its own pen.
+    const readScale = useCallback(() => getPenScale(editor), [editor]);
+    const scale = useSyncExternalStore(subscribePenScale, readScale, readScale);
 
     const pickColor = useCallback((next: TLDefaultColorStyle) => {
         editor.run(() => {
@@ -71,7 +74,7 @@ export default function CanvasStylePanel() {
 
     const changeWidth = useCallback((position: number) => {
         const next = sliderToPenScale(position);
-        setPenScale(next);
+        setPenScale(editor, next);
         // Apply to anything selected, so the slider re-inks a stroke already
         // drawn rather than only the next one.
         const selected = editor.getSelectedShapes().filter(s => 'scale' in s.props);

--- a/src/components/DrawingPane.tsx
+++ b/src/components/DrawingPane.tsx
@@ -3,7 +3,8 @@ import { Tldraw, getSnapshot } from 'tldraw';
 import type { Editor, TLEditorSnapshot } from 'tldraw';
 import 'tldraw/tldraw.css';
 import type { Theme } from '../types';
-import { CANVAS_COMPONENTS, applyPenDefaults } from './canvasPen';
+import { CANVAS_COMPONENTS, applyCanvasUi, applyPenDefaults, readCanvasUi, type CanvasUiState } from './canvasPen';
+import { subscribePenScale } from '../utils/penStyle';
 
 interface DrawingPaneProps {
     /** The drawing's vault path. Every change is reported against it explicitly
@@ -16,15 +17,6 @@ interface DrawingPaneProps {
     theme: Theme;
 }
 
-/** The tool and style pickers (color, pen size, dash, fill…) live in tldraw's
- *  instance state, which its document AND session snapshots both omit — so
- *  they're persisted as an extra `ui` block in the file, and put back on open
- *  exactly as the user left them. */
-interface SavedUiState {
-    toolId?: string;
-    stylesForNextShape?: Record<string, unknown>;
-}
-
 /** Drawing a single stroke fires a burst of store transactions; serializing the
  *  whole document on each one would be wasteful. Coalesce, then hand off to the
  *  app's own 1s save debounce. */
@@ -34,12 +26,12 @@ const SERIALIZE_DEBOUNCE_MS = 400;
  *  rendering; past it, tldraw's low-zoom thin-line LOD applies as designed. */
 const FULL_INK_SHAPE_LIMIT = 1000;
 
-function parseDrawingFile(content: string): { snapshot?: TLEditorSnapshot; ui?: SavedUiState } {
+function parseDrawingFile(content: string): { snapshot?: TLEditorSnapshot; ui?: CanvasUiState } {
     if (!content.trim()) return {}; // new/empty file → blank canvas
     try {
         // Files written before the `ui` block existed are plain snapshots;
         // destructuring just yields ui === undefined for those.
-        const { ui, ...snapshot } = JSON.parse(content) as TLEditorSnapshot & { ui?: SavedUiState };
+        const { ui, ...snapshot } = JSON.parse(content) as TLEditorSnapshot & { ui?: CanvasUiState };
         return { snapshot, ui };
     } catch (err) {
         // Don't destroy an unreadable file: mounting blank would autosave over
@@ -48,13 +40,6 @@ function parseDrawingFile(content: string): { snapshot?: TLEditorSnapshot; ui?: 
         console.error('Could not parse drawing (leaving the file untouched):', err);
         return {};
     }
-}
-
-function readUiState(editor: Editor): SavedUiState {
-    return {
-        toolId: editor.getCurrentToolId(),
-        stylesForNextShape: editor.getInstanceState().stylesForNextShape,
-    };
 }
 
 /**
@@ -106,29 +91,18 @@ export default function DrawingPane({ filePath, content, onContentChange, theme 
                 ? realEfficientZoom()
                 : Math.max(0.5, realEfficientZoom());
 
-        // Restore the saved pickers BEFORE the listeners attach: these writes
-        // are indistinguishable from user edits, and a restore must not mark a
-        // just-opened file dirty.
-        if (ui) {
-            try {
-                if (ui.stylesForNextShape) {
-                    editor.updateInstanceState({ stylesForNextShape: ui.stylesForNextShape });
-                }
-                if (ui.toolId) editor.setCurrentTool(ui.toolId);
-            } catch (err) {
-                // A tool/style saved by a newer build than this one — the
-                // defaults are a fine fallback, the drawing itself is intact.
-                console.warn('Could not restore drawing UI state:', err);
-            }
-        }
-
+        // Restore the saved pen BEFORE the listeners attach: these writes are
+        // indistinguishable from user edits, and a restore must not mark a
+        // just-opened file dirty. Also before applyPenDefaults, whose shape
+        // handler reads the width this seeds.
+        applyCanvasUi(editor, ui);
         const disposePen = applyPenDefaults(editor);
 
-        let lastUi = JSON.stringify(readUiState(editor));
+        let lastUi = JSON.stringify(readCanvasUi(editor));
 
         const flush = () => {
             serializeTimerRef.current = null;
-            const uiNow = readUiState(editor);
+            const uiNow = readCanvasUi(editor);
             lastUi = JSON.stringify(uiNow);
             onContentChangeRef.current(filePath, JSON.stringify({ ...getSnapshot(editor.store), ui: uiNow }));
         };
@@ -145,15 +119,21 @@ export default function DrawingPane({ filePath, content, onContentChange, theme 
         // The pickers live in session scope alongside camera/selection noise
         // that must NOT dirty the file — so compare just the slice we persist
         // and only save when THAT changed.
-        const unlistenSession = editor.store.listen(() => {
-            if (JSON.stringify(readUiState(editor)) !== lastUi) schedule();
-        }, { source: 'user', scope: 'session' });
+        const saveUiIfChanged = () => {
+            if (JSON.stringify(readCanvasUi(editor)) !== lastUi) schedule();
+        };
+        const unlistenSession = editor.store.listen(saveUiIfChanged, { source: 'user', scope: 'session' });
+        // Pen WIDTH is not a tldraw style, so changing it touches no store and
+        // the listener above never sees it. Without this the width was only
+        // remembered if you happened to draw afterwards.
+        const unlistenPen = subscribePenScale(saveUiIfChanged);
 
         return () => {
             editorRef.current = null;
             disposePen();
             unlistenDoc();
             unlistenSession();
+            unlistenPen();
             // Unmounting mid-debounce (tab switch, tab close) must not drop the
             // last strokes — flush them synchronously while the editor is alive.
             if (serializeTimerRef.current) {

--- a/src/components/NotebookPane.tsx
+++ b/src/components/NotebookPane.tsx
@@ -10,7 +10,8 @@ import { parseNotebookFile, serializeNotebookFile, type NotebookUiState } from '
 import { isEmptyOverlay, type PageOverlay } from '../utils/pdfOverlay';
 import { svgToVectorOps } from '../utils/pdfVector';
 import { setNotebookRenderData } from '../utils/notebookRenderCache';
-import { CANVAS_COMPONENTS, applyPenDefaults } from './canvasPen';
+import { CANVAS_COMPONENTS, applyCanvasUi, applyPenDefaults, readCanvasUi } from './canvasPen';
+import { subscribePenScale } from '../utils/penStyle';
 
 interface NotebookPaneProps {
     /** The notebook's vault path. Every change is reported against it explicitly
@@ -271,26 +272,18 @@ export default function NotebookPane({ filePath, content, onContentChange, onCon
                 ? realEfficientZoom()
                 : Math.max(0.5, realEfficientZoom());
 
+        // Before applyPenDefaults, whose shape handler reads the width this
+        // seeds, and before the listeners attach — restoring what the file
+        // already says must not mark it dirty.
+        applyCanvasUi(editor, uiRef.current);
         const disposePen = applyPenDefaults(editor);
 
         // Everything below runs BEFORE the listeners attach, so none of it marks
         // a just-opened file dirty.
         layOutPages(editor, paperRef.current);
 
-        const ui = uiRef.current;
-        if (ui) {
-            try {
-                if (ui.stylesForNextShape) editor.updateInstanceState({ stylesForNextShape: ui.stylesForNextShape });
-                if (ui.toolId) editor.setCurrentTool(ui.toolId);
-            } catch (err) {
-                // A tool or style saved by a newer build — the defaults are a
-                // fine fallback and the writing itself is intact.
-                console.warn('Could not restore notebook UI state:', err);
-            }
-        } else {
-            // A new notebook opens ready to write on, not ready to select.
-            editor.setCurrentTool('draw');
-        }
+        // A new notebook opens ready to write on, not ready to select.
+        if (!uiRef.current?.toolId) editor.setCurrentTool('draw');
 
         // Frame the first page on a first-ever open; a reopen restores the
         // camera from the snapshot, and fitting would throw away where the user
@@ -300,10 +293,7 @@ export default function NotebookPane({ filePath, content, onContentChange, onCon
             editor.zoomToBounds(new Box(0, 0, size.width, size.height), { inset: FIT_INSET });
         }
 
-        const readUi = (): NotebookUiState => ({
-            toolId: editor.getCurrentToolId(),
-            stylesForNextShape: editor.getInstanceState().stylesForNextShape,
-        });
+        const readUi = () => readCanvasUi(editor);
         let lastUi = JSON.stringify(readUi());
 
         const flush = () => {
@@ -327,15 +317,21 @@ export default function NotebookPane({ filePath, content, onContentChange, onCon
         const unlistenDoc = editor.store.listen(schedule, { source: 'user', scope: 'document' });
         // The pickers live in session scope alongside camera noise that must NOT
         // dirty the file, so compare just the slice that gets persisted.
-        const unlistenSession = editor.store.listen(() => {
+        const saveUiIfChanged = () => {
             if (JSON.stringify(readUi()) !== lastUi) schedule();
-        }, { source: 'user', scope: 'session' });
+        };
+        const unlistenSession = editor.store.listen(saveUiIfChanged, { source: 'user', scope: 'session' });
+        // Pen WIDTH is not a tldraw style, so changing it touches no store and
+        // the listener above never sees it. Without this the width was only
+        // remembered if you happened to write afterwards.
+        const unlistenPen = subscribePenScale(saveUiIfChanged);
 
         return () => {
             editorRef.current = null;
             disposePen();
             unlistenDoc();
             unlistenSession();
+            unlistenPen();
             // Unmounting mid-debounce (tab switch, tab close) must not drop the
             // last strokes — flush them while the editor is still alive.
             if (serializeTimerRef.current) {

--- a/src/components/PdfAnnotateCanvas.tsx
+++ b/src/components/PdfAnnotateCanvas.tsx
@@ -6,7 +6,7 @@ import { pageLayout, openPdfPages, PAGE_RENDER_SCALE, type PdfPageSize, type Pdf
 import { setPdfRenderData } from '../utils/pdfRenderCache';
 import { isEmptyOverlay, type PageOverlay } from '../utils/pdfOverlay';
 import { svgToVectorOps } from '../utils/pdfVector';
-import { CANVAS_COMPONENTS, applyPenDefaults } from './canvasPen';
+import { CANVAS_COMPONENTS, applyCanvasUi, applyPenDefaults, readCanvasUi, type CanvasUiState } from './canvasPen';
 
 interface PdfAnnotateCanvasProps {
     filePath: string;
@@ -124,13 +124,22 @@ function refreshPageAsset(editor: Editor | null, index: number): void {
     });
 }
 
-function parseSnapshot(content: string): TLEditorSnapshot | undefined {
-    if (!content.trim()) return undefined;
+/**
+ * The snapshot embedded in an annotated PDF, plus the `ui` block beside it.
+ *
+ * tldraw's snapshots carry no styles at all (see CanvasUiState), so without
+ * this an annotated PDF reopened with the default colour and width however it
+ * was left — unlike a drawing or a notebook, which have always saved theirs.
+ * A file written before this block existed simply yields `ui: undefined`.
+ */
+function parseSnapshot(content: string): { snapshot?: TLEditorSnapshot; ui?: CanvasUiState } {
+    if (!content.trim()) return {};
     try {
-        return JSON.parse(content) as TLEditorSnapshot;
+        const { ui, ...snapshot } = JSON.parse(content) as TLEditorSnapshot & { ui?: CanvasUiState };
+        return { snapshot: 'document' in snapshot ? snapshot as TLEditorSnapshot : undefined, ui };
     } catch (err) {
         console.error('Could not parse PDF annotations (leaving the file untouched):', err);
-        return undefined;
+        return {};
     }
 }
 
@@ -159,6 +168,7 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
     // (and could clobber in-progress strokes). PdfPane keys this component on
     // the file path, so a different file means a fresh mount and a fresh parse.
     const [parsed] = useState(() => parseSnapshot(snapshot));
+    const uiRef = useRef<CanvasUiState | undefined>(parsed.ui);
     const serializeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     /** Page images as they arrive, by page index. Read by the asset store. */
     const pageImagesRef = useRef<Array<PageImage | undefined>>([]);
@@ -308,7 +318,7 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
 
         // Frame the document only on a first-ever open. On a reopen the snapshot
         // restores the camera, and fitting would throw away where the user was.
-        if (!parsed) editor.zoomToFit();
+        if (!parsed.snapshot) editor.zoomToFit();
 
         for (const shape of editor.getCurrentPageShapes()) {
             if (shape.meta?.pdfPage !== undefined) pageShapeIdsRef.current.add(shape.id);
@@ -496,13 +506,24 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
             // Hand the binary to the save path, then report the snapshot as this
             // tab's content — that marks it dirty and triggers the write.
             setPdfRenderData(filePath, { original, overlays });
-            const json = JSON.stringify(getSnapshot(editor.store));
+            uiRef.current = readCanvasUi(editor);
+            const json = JSON.stringify({ ...getSnapshot(editor.store), ui: uiRef.current });
             if (immediate) onFlushNowRef.current(filePath, json);
             else onContentChangeRef.current(filePath, json);
         };
 
+        // Before applyPenDefaults, whose shape handler reads the width this
+        // seeds, and before the listeners attach — restoring what the file
+        // already says must not mark it dirty and rewrite the whole PDF.
+        applyCanvasUi(editor, uiRef.current);
         const disposePen = applyPenDefaults(editor);
 
+        /* Deliberately document-scope only, unlike a drawing or a notebook,
+           which also save when the pen alone changes. A PDF's save REBUILDS THE
+           WHOLE DOCUMENT (~150ms per annotated page), so doing that because a
+           colour was clicked would stall the pen for nothing. The pen is
+           captured by the next stroke's flush instead, which is the moment it
+           first matters. */
         const unlisten = editor.store.listen(() => {
             hasUnsavedRef.current = true;
             if (serializeTimerRef.current) clearTimeout(serializeTimerRef.current);
@@ -523,7 +544,7 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
                 void flush(true);
             }
         };
-    }, [filePath, original, pages, parsed]);
+    }, [filePath, original, pages, parsed.snapshot]);
 
     if (error) {
         return (
@@ -540,7 +561,7 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
     return (
         <div className="drawing-pane pdf-annotate-pane">
             <Tldraw
-                snapshot={parsed}
+                snapshot={parsed.snapshot}
                 assets={assetStore}
                 onMount={handleMount}
                 components={CANVAS_COMPONENTS}

--- a/src/components/canvasPen.ts
+++ b/src/components/canvasPen.ts
@@ -9,8 +9,58 @@
 
 import type { Editor, TLShape } from 'tldraw';
 import { DefaultDashStyle, DefaultSizeStyle } from 'tldraw';
-import { getPenScale } from '../utils/penStyle';
+import { getPenScale, seedPenScale } from '../utils/penStyle';
 import CanvasStylePanel from './CanvasStylePanel';
+
+/**
+ * What a canvas file remembers about how you were drawing in it.
+ *
+ * tldraw's own snapshots carry NONE of this: a document snapshot holds shapes
+ * and a session snapshot holds the camera and selection (TLSessionStateSnapshot
+ * is the whole list — no styles). So a file that did not save this block
+ * reopened with the default colour and width however it was left, which is what
+ * "each file remembers its own pen" is about.
+ *
+ * Written into every canvas file's `ui` key: `.tldraw`, `.notebook`, and the
+ * snapshot embedded in an annotated PDF.
+ */
+export interface CanvasUiState {
+    toolId?: string;
+    /** tldraw's own style memory — colour, and anything else it tracks. */
+    stylesForNextShape?: Record<string, unknown>;
+    /** Pen width. Not a tldraw style (it is `props.scale`), so it is kept here
+     *  rather than inside stylesForNextShape. See utils/penStyle.ts. */
+    penScale?: number;
+}
+
+/** What to write into the file. */
+export function readCanvasUi(editor: Editor): CanvasUiState {
+    return {
+        toolId: editor.getCurrentToolId(),
+        stylesForNextShape: editor.getInstanceState().stylesForNextShape,
+        penScale: getPenScale(editor),
+    };
+}
+
+/**
+ * Put a file's remembered pen back.
+ *
+ * MUST run before the save listeners attach: these writes are indistinguishable
+ * from user edits, and restoring what a file already says must not mark it
+ * dirty and rewrite it.
+ */
+export function applyCanvasUi(editor: Editor, ui: CanvasUiState | undefined): void {
+    seedPenScale(editor, ui?.penScale);
+    if (!ui) return;
+    try {
+        if (ui.stylesForNextShape) editor.updateInstanceState({ stylesForNextShape: ui.stylesForNextShape });
+        if (ui.toolId) editor.setCurrentTool(ui.toolId);
+    } catch (err) {
+        // A tool or style saved by a newer build than this one — the defaults
+        // are a fine fallback, and the drawing itself is untouched.
+        console.warn('Could not restore this canvas\'s tools:', err);
+    }
+}
 
 /** What every canvas in the app passes to <Tldraw components={...}>. */
 export const CANVAS_COMPONENTS = { StylePanel: CanvasStylePanel };
@@ -41,6 +91,6 @@ export function applyPenDefaults(editor: Editor): () => void {
         // widens them past the discriminant, and the guard above is what makes
         // the write sound.
         if (!('scale' in shape.props)) return shape;
-        return { ...shape, props: { ...shape.props, scale: getPenScale() } } as TLShape;
+        return { ...shape, props: { ...shape.props, scale: getPenScale(editor) } } as TLShape;
     });
 }

--- a/src/utils/helpDoc.ts
+++ b/src/utils/helpDoc.ts
@@ -221,6 +221,12 @@ default. The dot beside it is the actual width, in the actual colour, so you can
 see what you are about to draw with. Drag the slider or pick a colour with
 something selected and it re-inks that instead of only the next stroke.
 
+**Every file keeps its own pen.** A notebook you annotate in fine red stays fine
+and red; the PDF you were marking up in thick blue is still thick and blue when
+you come back to it, however many other things you drew in between. A brand new
+file starts at the width you were last using, since that is usually the one you
+want again.
+
 ### Drawings
 A **drawing** (\`.tldraw\`) is the same canvas with no pages at all — an endless
 sheet in every direction, for diagrams and thinking rather than for a page you

--- a/src/utils/notebookFile.ts
+++ b/src/utils/notebookFile.ts
@@ -18,13 +18,11 @@
 
 import type { TLEditorSnapshot } from 'tldraw';
 import { normalizePaper, type NotebookPaper } from './paper';
+import type { CanvasUiState } from '../components/canvasPen';
 
-/** The tool and style pickers, which tldraw's document AND session snapshots
- *  both omit — so they are persisted here and put back on open. */
-export interface NotebookUiState {
-    toolId?: string;
-    stylesForNextShape?: Record<string, unknown>;
-}
+/** The pen this notebook was last written with. One shape across all three
+ *  canvases — see components/canvasPen.ts. */
+export type NotebookUiState = CanvasUiState;
 
 export interface NotebookFile {
     paper: NotebookPaper;

--- a/src/utils/penStyle.ts
+++ b/src/utils/penStyle.ts
@@ -1,10 +1,13 @@
-// How thick the pen is, app-wide.
+// How thick the pen is — PER OPEN CANVAS, remembered per file.
 //
-// AN EXTERNAL STORE, not a prop and not per-file, for the same reason
-// `saveEpoch` is one: the value is read by a panel inside every canvas, and two
-// canvases can be on screen at once in a split — a per-pane copy would let the
-// two drift apart while both claimed to be "the pen". One value, one
-// subscription, persisted like the rest of the appearance settings.
+// Keyed on the live editor rather than held as one app-wide value, because a
+// split can show two canvases at once and each answers to its own file: the
+// width belongs to the document you are writing in, not to the app. The panel
+// inside a canvas reads its own editor's entry; the pane that owns that editor
+// writes the value into the file's `ui` block and hands it back on reopen.
+//
+// A WeakMap, so a closed canvas's entry goes when its editor does — there is no
+// unmount hook that could be trusted to run for every editor that ever existed.
 //
 // WHY A NUMBER AND NOT A SIZE. tldraw's thickness is the four-step `size` style
 // (s/m/l/xl), and its thinnest, `s`, is still 3px of ink — too heavy for small
@@ -19,7 +22,11 @@
 // reopen, and rides the vector export as a uniform transform — nothing about
 // this is a display-only trick.
 
-const STORAGE_KEY = 'penScale';
+import type { Editor } from 'tldraw';
+
+/** Remembers the last width used anywhere, so a file that has never been drawn
+ *  in opens at the width you were last working at rather than at the default. */
+const LAST_USED_KEY = 'penScale';
 
 /** Thinnest the slider goes: 3 * 0.12 ≈ 0.36px of ink, about as fine as a
  *  0.3mm technical pen and still visible at 100%. */
@@ -29,37 +36,60 @@ export const MIN_PEN_SCALE = 0.12;
  *  asked for, but a pen that could no longer be thick would be a loss. */
 export const MAX_PEN_SCALE = 3.5;
 
-/** tldraw's `size: 's'` at scale 1 — the width the app opens with, and the
- *  reference the slider is calibrated around. */
+/** tldraw's `size: 's'` at scale 1 — the reference the slider is calibrated
+ *  around, and the width used when nothing else is known. */
 export const DEFAULT_PEN_SCALE = 1;
 
-function clamp(value: number): number {
+export function clampPenScale(value: number): number {
     if (!Number.isFinite(value)) return DEFAULT_PEN_SCALE;
     return Math.min(MAX_PEN_SCALE, Math.max(MIN_PEN_SCALE, value));
 }
 
-let scale = clamp(Number(localStorage.getItem(STORAGE_KEY) ?? DEFAULT_PEN_SCALE));
+const scales = new WeakMap<Editor, number>();
 const listeners = new Set<() => void>();
 
-export function getPenScale(): number {
-    return scale;
+/** The width the last canvas to be adjusted was set to, across sessions. */
+function lastUsed(): number {
+    try {
+        const stored = localStorage.getItem(LAST_USED_KEY);
+        return stored === null ? DEFAULT_PEN_SCALE : clampPenScale(Number(stored));
+    } catch {
+        // A blocked localStorage costs the memory, not the pen.
+        return DEFAULT_PEN_SCALE;
+    }
 }
 
-export function setPenScale(next: number): void {
-    const clamped = clamp(next);
-    if (clamped === scale) return;
-    scale = clamped;
+/**
+ * Seed a canvas's width, from the file if it recorded one.
+ *
+ * Called before the panel first renders, so the slider never shows a width the
+ * canvas is not actually drawing at. A file with nothing recorded inherits the
+ * width you were last using, which is friendlier than snapping every new
+ * notebook back to the default.
+ */
+export function seedPenScale(editor: Editor, saved: number | undefined): void {
+    scales.set(editor, saved === undefined ? lastUsed() : clampPenScale(saved));
+    for (const listener of listeners) listener();
+}
+
+export function getPenScale(editor: Editor): number {
+    return scales.get(editor) ?? DEFAULT_PEN_SCALE;
+}
+
+export function setPenScale(editor: Editor, next: number): void {
+    const clamped = clampPenScale(next);
+    if (clamped === scales.get(editor)) return;
+    scales.set(editor, clamped);
     try {
-        localStorage.setItem(STORAGE_KEY, String(clamped));
+        localStorage.setItem(LAST_USED_KEY, String(clamped));
     } catch (err) {
-        // A full or blocked localStorage must not stop the pen changing width;
-        // it only costs the setting across a reload.
-        console.warn('Could not save the pen width:', err);
+        console.warn('Could not remember the pen width for new files:', err);
     }
     for (const listener of listeners) listener();
 }
 
-/** `useSyncExternalStore`'s subscribe half. */
+/** `useSyncExternalStore`'s subscribe half. One notification for every canvas —
+ *  there are at most a handful on screen, and each reads only its own entry. */
 export function subscribePenScale(listener: () => void): () => void {
     listeners.add(listener);
     return () => listeners.delete(listener);
@@ -75,10 +105,10 @@ export function subscribePenScale(listener: () => void): () => void {
  */
 export function penScaleToSlider(value: number): number {
     const span = Math.log(MAX_PEN_SCALE) - Math.log(MIN_PEN_SCALE);
-    return (Math.log(clamp(value)) - Math.log(MIN_PEN_SCALE)) / span;
+    return (Math.log(clampPenScale(value)) - Math.log(MIN_PEN_SCALE)) / span;
 }
 
 export function sliderToPenScale(position: number): number {
     const span = Math.log(MAX_PEN_SCALE) - Math.log(MIN_PEN_SCALE);
-    return clamp(Math.exp(Math.log(MIN_PEN_SCALE) + position * span));
+    return clampPenScale(Math.exp(Math.log(MIN_PEN_SCALE) + position * span));
 }


### PR DESCRIPTION
The pen width was one app-wide setting, and the colour was remembered by drawings and notebooks but not by PDFs. So marking up a PDF in thick blue and then writing a notebook in fine red left both of them wrong on the way back. All three canvases now keep their own pen, in the file.

## What changed

- **`penStyle` keys on the live `Editor`** (a `WeakMap`) instead of holding one global value. A split shows two canvases at once and each answers to its own document, so the width belongs to the file rather than to the app.
- **`CanvasUiState`** (`toolId` + `stylesForNextShape` + `penScale`) is now one shape written into every canvas file's `ui` key, replacing the two near-identical copies `DrawingPane` and `NotebookPane` each carried.
- **Annotated PDFs gain that block for the first time.** tldraw's snapshots hold no styles at all — `TLSessionStateSnapshot` is camera and selection, full stop — which is exactly why PDFs were the ones forgetting.

## Two things worth a reviewer's eye

**Ordering.** `applyCanvasUi` runs *before* `applyPenDefaults`, whose shape handler reads the width it seeds, and *before* the save listeners attach — otherwise restoring what a file already says marks it dirty and rewrites it.

**Pen width is not a tldraw style**, so changing it touches no store and the session listener never sees it; the width was only remembered if you happened to draw afterwards. The drawing and notebook panes therefore subscribe to the pen store as well. `PdfAnnotateCanvas` deliberately does not — a PDF's save rebuilds the whole document at ~150ms per annotated page, and doing that because a colour was clicked would stall the pen for nothing, so its pen rides the next stroke's flush.

A file with nothing recorded opens at the width last used anywhere rather than snapping to the default.

## Verification

Driven headlessly against an OPFS-stubbed vault, on the dev server and again on the production build: three files set to different pens, then a full reload — a notebook at 0.135 red, another at 3.5 green, and a PDF mid-width blue, each coming back with its own and the values readable in the files on disk.

`npm run typecheck`, `npm run lint` and `npm run build` all clean. Regression-checked in-place PDF annotation (embedded original still byte-identical, no compounding), notebook page add/delete, and notebook PDF export.