### PR TITLE
Fix a PDF opened for reading sitting on "Loading PDF…" forever

### DIFF
--- a/src/components/PdfPane.tsx
+++ b/src/components/PdfPane.tsx
@@ -256,24 +256,29 @@ function PdfPane({ file, isVisible, isFocused, slotIndex, slotLeft, slotWidth, i
     if (activated) {
         if (error) {
             body = <div className="pdf-pane-message">Could not open this PDF: {error}</div>;
-        } else if (!source) {
+        } else if (mode === 'edit' && !source) {
+            /* Waiting on the ROLE read, which is lazy — only annotating needs
+               it. Gating every branch on it (as this did) left a PDF opened for
+               reading stuck on "Loading PDF…" forever, waiting for a read that
+               no longer happens until you switch to annotate. Reading needs
+               `viewBytes` and nothing else; that is the branch further down. */
             body = <div className="pdf-pane-message">Loading PDF…</div>;
-        } else if (mode === 'edit' && source.notebookSource) {
+        } else if (mode === 'edit' && source?.notebookSource) {
             // A notebook's export. Annotating it would fork a third document
             // whose marks the notebook could neither see nor replace, so the
             // pane hands you back to the notebook instead of drawing anything.
             body = (
                 <div className="pdf-pane-message">
-                    This PDF was exported from <strong>{source.notebookSource.path}</strong>.
+                    This PDF was exported from <strong>{source!.notebookSource!.path}</strong>.
                     <button
                         className="pdf-pane-action"
-                        onClick={() => onOpenNotebookSource(file.path, source.notebookSource!.path)}
+                        onClick={() => onOpenNotebookSource(file.path, source!.notebookSource!.path)}
                     >
                         Open the notebook
                     </button>
                 </div>
             );
-        } else if (mode === 'edit') {
+        } else if (mode === 'edit' && source) {
             // The annotate canvas only exists while its document is on screen:
             // a hidden tldraw instance would pin megabytes of page bitmaps, and
             // unmounting it is what flushes pending strokes to disk.


### PR DESCRIPTION
Regression from #1's predecessor (in-place PDF annotation), currently live: clicking a PDF leaves it on **"Loading PDF…"** and it only renders after switching to annotate mode and back.

## Cause

Making annotation happen in place meant *every* PDF became annotatable, so the role read — is there an embedded `original.pdf`, is this a notebook's export — could no longer be gated on the filename. Reading it for every PDF on open would be an N-MB allocation and a disk read for documents nobody draws on, so it was made lazy: performed on the first switch to annotate mode.

The render branch wasn't moved with it. `!source` still guarded *every* case, including reading, so a PDF opened to read waited on a read that no longer happens until you annotate. Switching to annotate and back "fixed" it because that's what triggered the read.

Reading needs `viewBytes` and nothing else, so the wait now belongs to annotate mode alone.

## Why the tests missed it

They waited for `.pdf-viewer-page, .pdf-pane-message` — and `"Loading PDF…"` **is** a `.pdf-pane-message`, so they passed on the very text that meant failure.

The new test asserts pages are rendered *and* no message is showing, across four cases: a plain PDF opened cold, a second in the same session, returning to reading after annotating, and an already-annotated PDF opened cold. It was checked against the bug before being kept — with the old line restored all four report `pages=0, message="Loading PDF…"`; with the fix all four pass.

## Verification

`typecheck`, `lint`, `build` clean. Regressions re-run: in-place annotation (embedded original still byte-identical, no compounding), per-file pen memory, and the notebook→PDF→notebook round trip.