### PR TITLE
Make tab switching, the sidebar and PDF zoom fast again

### DIFF
--- a/.agents/skills/pdf-and-drawings/SKILL.md
+++ b/.agents/skills/pdf-and-drawings/SKILL.md
@@ -61,6 +61,18 @@ as live tldraw shapes.
 - `pdfBuildClient` keeps one warm `Worker` for the app's life, and on `worker.onerror` rejects every
   in-flight build and nulls the worker so the next call re-spawns it.
 
+## One pdf.js worker for the whole app — `utils/pdfWorker.ts`
+
+pdf.js spawns a worker **per `getDocument`** unless it is handed one, and a loading task only tears
+down a worker it created itself (`task._worker` is set only when the caller passed none) — so passing
+a shared one is safe, and is the whole fix. Opening a single PDF used to start two workers: `PdfPane`
+probes the file's role via `readPdfRole` before it knows which view to show, then `PdfViewer` opens
+the same bytes again; each boot loads and compiles ~1MB of worker script before a byte is read.
+**Pass `worker: pdfWorker()` to every `getDocument`.** That module is also the one place that sets
+`GlobalWorkerOptions.workerSrc` — importing it is how the PDF modules get the assignment. Verified by
+counting `new Worker(...)`: one for the session, zero more per PDF opened. `prefetchPanes` starts it
+at idle (dynamically, or pdf.js lands in the main bundle), so the boot is off the first click.
+
 ## Deliberate module fragmentation is for bundle size — do not collapse it
 
 pdf-lib (~400kB) + pdf.js must stay out of the main bundle for markdown-only sessions. There is no
@@ -97,11 +109,35 @@ requires reading it.
   positioned span, so a dense 300-page book runs to hundreds of MB). Above 300 the *eager* pass is
   skipped, but layers are still built on demand for every page that scrolls into view and still never
   freed. **Do not "fix" this by lowering the limit or windowing the layers without an explicit
-  decision — both trade away ⌘F completeness.** (`content-visibility: auto` on `.pdf-viewer-page`
-  looks like the free answer and **is not**: measured 533.8MB → 542.1MB, slightly worse, because Blink
-  does not tear down layout structures already built.) The eager pass is keyed on a `hasLayout`
-  boolean rather than the `layout` object identity, so a zoom or resize does not restart 300
-  iterations.
+  decision — both trade away ⌘F completeness.** The eager pass is keyed on a `hasLayout` boolean rather
+  than the `layout` object identity, so a zoom or resize does not restart 300 iterations.
+- **`content-visibility: auto` on `.pdf-viewer-page` buys TIME, not MEMORY** — know which problem you
+  are measuring before judging it. Memory: it does nothing (measured 533.8MB → 542.1MB, slightly
+  *worse*, because Blink does not tear down layout structures already built), so it is no answer to the
+  text layers above. Per-frame cost: it is decisive, because every zoom step changes `--scale-factor`
+  and so restyles every text-layer span and repaints the whole column — 40 pages of style, layout and
+  compositor commit to change what two of them show. Measured on a 40-page document at 4x CPU: blocked
+  main thread per zoom step 223ms → 122ms, a 4-step `-` burst 452ms → 177ms, 45fps → 55fps. It needs no
+  `contain-intrinsic-size` here: each page div carries explicit inline width/height from the layout, so
+  a skipped page still reserves exactly the right box. Verified it does not cost ⌘F: with and without,
+  find lands on the same page at the same rect (`window.find` → identical geometry, A/B'd in-page).
+- **A page's bitmap is capped at `MAX_CANVAS_PIXELS` (2^24 device px, ~67MB), and past the cap the page
+  is rendered ONE BAND AT A TIME.** A canvas used to grow with the zoom even though the viewport only
+  ever showed a sliver: measured at 4x zoom, two canvases of 9440x12216 — 231 megapixels, **~923MB** of
+  backing store — which is what made zooming out of a 40-page document run at 7fps with 1.3s of blocked
+  main thread. `pageRegion` answers with the visible strip grown by as much margin as the budget still
+  affords (`rect`), the strictly visible part that must be painted (`need`), and `rect` pulled in by
+  half that margin (`trigger`). A re-render is worth doing once `need` escapes `trigger` — deflating is
+  what stops a one-pixel scroll from re-rendering, and only deflating sides that are not already a page
+  edge is what keeps it from asking to re-render what it just rendered. Band rendering is a translate
+  on top of the dpr scale in pdf.js's `transform`; the canvas is then pinned over its band with inline
+  `left/top/width/height`, which is why `.pdf-viewer-page > canvas` uses `top/left`, not `inset: 0`.
+  **Capping the SCALE instead would have been ~10 lines and is the wrong trade** — zoom exists to read
+  fine print, so going soft at high zoom defeats the gesture. Now flat with zoom: 923MB → 63MB.
+- **Rasterize off-screen, then blit.** Sizing a canvas wipes it, so rendering in place left the page
+  blank white for the length of every zoom step — and, now that a scroll at zoom can re-render, for
+  those too. The spare canvas is skipped on a page's FIRST render, where there is nothing to preserve
+  and it would only double the cold-open cost.
 - Canvas **bitmaps are windowed**: only pages within `EVICT_BEYOND` (3) of the viewport hold one
   (~25-31MB each at Retina fit-width); scrolled-away canvases are freed and re-rendered on approach,
   and pages further than `CLEANUP_BEYOND` (12) also get `page.cleanup()` so pdf.js releases their

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,30 +12,29 @@ nothing. So the test is never "is this true and useful" (almost everything is) b
 
 > **Is this worth removing something else to make room for?**
 
-If no, it does not go here. If yes, name what you cut and cut it in the same change — though while
-the file is *under* 150 that room already exists, so add freely without removing anything: spare
-budget is there to be spent, and a file that uses it well beats one that leaves it on the table.
-Where it goes instead:
+If no, it does not go here. If yes, name what you cut and cut it in the same change — though while the
+file is *under* 150 that room already exists, so add freely: spare budget is there to be spent, and a
+file that uses it well beats one that leaves it on the table. Where it goes instead:
 
 1. **Has a detectable trigger** ("when editing a table", "when touching the PDF pipeline") → a
    **skill**, loaded only when needed and costing nothing otherwise. This is the default answer.
 2. **Broad and unconditional** — every change must respect it, whatever it touches → this file.
-3. **Neither** → bloat: delete it, or leave it as a comment beside the code, where a narrow fact
-   stays honest longest. A fact with no trigger is not a skill either — never invent one to hold it.
+3. **Neither** → bloat: delete it, or leave it as a comment beside the code, where a narrow fact stays
+   honest longest. A fact with no trigger is not a skill either — never invent one to hold it.
 
 Skills live in `.agents/skills/<name>/SKILL.md`.
 
 ## What this is
 
 A local-first, Obsidian-style Markdown editor that runs **entirely in the browser** with no backend,
-database, or network. It reads and writes the user's real files through the **File System Access
-API**, so it is **Chromium-only by design** (`showDirectoryPicker`, OPFS, `color-mix` are used
-freely). Stack: **React 19 + Vite 7 + TypeScript 6 + CodeMirror 6**, plus KaTeX, mermaid, tldraw
-(whiteboards, ruled notebooks, PDF annotation), pdf.js + pdf-lib, idb-keyval.
+database, or network. It reads and writes the user's real files through the **File System Access API**,
+so it is **Chromium-only by design** (`showDirectoryPicker`, OPFS, `color-mix` are used freely). Stack:
+**React 19 + Vite 7 + TypeScript 6 + CodeMirror 6**, plus KaTeX, mermaid, tldraw (whiteboards, ruled
+notebooks, PDF annotation), pdf.js + pdf-lib, idb-keyval.
 
-> Converted from JS to TS: many comments cite `.jsx` line numbers from pre-conversion files, and in
-> `src/types/index.ts` the *numbers* are wrong too — never navigate by them, grep. That file is still
-> the source of truth for domain types.
+> Converted from JS to TS: comments cite stale `.jsx` line numbers — grep, never navigate by them.
+> `src/types/index.ts` holds the domain types, and `declare global`s the File System Access API ones
+> (`showDirectoryPicker`, …) stock `lib.dom` lacks.
 
 ## Commands
 
@@ -63,16 +62,16 @@ and use it before saying a change works.
   unreferenced asset is *retired* into it and returns if the reference does, an unasked-for overwrite
   is renamed aside — which is why each costs a copy instead of a `removeEntry`. Prefer a wrong call
   that keeps a file over a right one that cannot be undone.
-- **State lives in `App.tsx`; the filesystem lives behind `useFileSystem()`.** App owns nearly all
-  state and every FS call goes through it. There is no backend and no undo stack behind it: a
-  mistake there destroys the user's notes.
+- **State lives in `App.tsx`; the filesystem lives behind `useFileSystem()`.** App owns nearly all state
+  and every FS call goes through it. There is no backend and no undo stack behind it: a mistake there
+  destroys the user's notes.
 - **Nothing overwrites an existing file by accident.** Every write that could land on a taken name
   goes through `freeEntryName`, which counts **both** files and folders; `moveFile`/`renameFile` and
   the notebook PDF export are the deliberate exceptions. **`createFile` is the hole** — it
   opens-or-*truncates*, guarded only at `App.handleCreateFile`; anything new calling it inherits it.
-- **`.Assets` (images) and `.Garbage` (trash) are per FOLDER**, owned by `utils/assets.ts` — nothing
-  else spells `'.Assets'` — and hidden, so a folder carries its own pictures and deletions wherever it
-  goes. `.appearance.json` is the third app-owned name, and the only root-only one (`entry-styles`).
+- **`.Assets` (images) and `.Garbage` (trash) are per FOLDER**, hidden, owned by `utils/assets.ts` — a
+  folder carries its own pictures and deletions wherever it goes. `.appearance.json` is the third
+  app-owned name and the only root-only one (`vault-filesystem`, `entry-styles`).
 - **Paths are vault-root-relative with no vault-name prefix**, centralized in `utils/paths.ts`;
   `buildFileTree` and every create/move/rename tab handler must agree or tabs stop deduping.
 - **The URL hash mirrors `{vault, file}`** (`utils/appUrl.ts`), NAMING a stored vault: the FS Access
@@ -85,30 +84,28 @@ and use it before saying a change works.
 - **A CodeMirror `EditorState` outlives the pane that built it**, and so does everything baked into
   it (`domEventHandlers`, the update listener); anything such a handler reaches must be **stable for
   the app's life**. A per-pane ref does not rescue that, it hides the staleness.
-- **Images and tables are deliberate abstractions over the app's own markdown**: the raw text is
-  unreachable by design, never revealed by the cursor, and the range is atomic. The file on disk
-  stays ordinary markdown — "the reader never sees the source" is the requirement.
+- **Images and tables are deliberate abstractions over the app's own markdown** — the raw text is
+  unreachable by design and the file on disk stays ordinary markdown (`markdown-tables` has the how).
 - **The app draws its own context menu and its own `confirm()`; prefer them to native dialogs.**
 - **TWO places turn note text into DOM `innerHTML`, safe for different reasons** — `tableWidget`'s
-  `renderCellContent` (attribute-free allowlist; one sink AND one write site, KaTeX splices in built
-  DOM, never a string) and `mermaidWidget`'s `renderInto` (mermaid's `securityLevel: 'strict'`
-  DOMPurify pass). This origin holds the vault's handle with permission granted, so a hole is
-  read/write over the whole vault. Do not open a third.
+  `renderCellContent` (attribute-free allowlist; one sink AND one write site, KaTeX splices in built DOM,
+  never a string) and `mermaidWidget`'s `renderInto` (mermaid's `securityLevel: 'strict'` DOMPurify pass).
+  This origin holds the vault's handle with permission granted, so a hole is read/write over the whole
+  vault. Do not open a third.
 - **Anything that walks the whole vault goes through a `(lastModified, size)`-validated cache**
-  (`utils/graph.ts`, `utils/vaultSearch.ts`) and holds one file's text at a time. Both run after
-  *every* save — an uncached walk is a full vault read per keystroke-triggered autosave.
-- **The editor's decoration pass runs per keystroke AND per arrow key, on every open pane** (a split
-  tab has up to five live documents). Anything added there must be memoized on immutable identity
-  (`Text`/tree, in a `WeakMap`), reuse a shared `Decoration`, or be measured — a per-node linear scan
-  once cost ~138ms/keystroke. Read mode is a **pure function of the document**.
+  (`utils/graph.ts`, `utils/vaultSearch.ts`) and holds one file's text at a time. Both run after *every*
+  save — an uncached walk is a full vault read per keystroke-triggered autosave.
+- **The decoration pass runs per keystroke, per arrow key, on every open pane** — memoize on immutable
+  identity or measure it; read mode stays a pure function of the document (`live-preview`).
 - **Long-running async work over the vault is serialized, never merely started** — trashing a folder,
-  asset reconciles, the recent-vaults read-modify-write and every vault switch (one gate for all
-  raisers, walking the new vault before committing anything) each hold an in-flight ref or a promise
-  queue: `StrictMode` double-runs effects and users click twice mid-copy.
+  asset reconciles, the recent-vaults read-modify-write and every vault switch each hold an in-flight
+  ref or a promise queue: `StrictMode` double-runs effects and users click twice mid-copy.
 - **The PDF/tldraw module split is bundle-size discipline enforced only by import discipline** —
   there is no manual chunking in `vite.config.ts`, so one new import silently pulls pdf-lib (~400kB),
   pdf.js or tldraw into the main bundle. Check the `pdf-and-drawings` skill (it covers notebooks and
-  drawings too) before adding one; `utils/paper.ts` importing nothing is part of that split.
+  drawings too) before adding one; `utils/paper.ts` importing nothing is part of that split. Those
+  chunks warm at idle via `components/prefetchPanes.ts`, gated on the kinds the open vault holds —
+  a markdown-only vault must keep fetching nothing.
 - **`readFile` normalizes `\r\n → \n`, and everything downstream depends on it** — CodeMirror does
   the same, so buffers and search offsets stay in step; a reader that skips it drifts on CRLF.
 - **The app's user documentation is a file in this repo** — `utils/helpDoc.ts`, one exported string
@@ -119,11 +116,16 @@ and use it before saying a change works.
 
 - **Object URLs are cached by file version, never minted per use** — keyed on path, validated on
   `(lastModified, size)`. Each pane likewise holds **one stable resolver identity and one stable
-  `imageActions`** for life; a fresh closure per call makes every image widget compare unequal on
-  every ⌘E and tab switch.
+  `imageActions`** for life; a fresh closure per call makes every image widget compare unequal on every
+  ⌘E and tab switch.
 - **`saveEpoch` is an external store** (`utils/saveEpoch.ts`), not a prop, and so are the context-menu,
-  entry-style and create-request stores. `FileExplorer`/`TreeNode` are `React.memo`'d so the tree stops
-  re-rendering while the user types — never thread a per-save/menu/search/icon/create value through.
+  entry-style, create-request and **active-file** stores. `FileExplorer`/`TreeNode` are `React.memo`'d so
+  the tree stops re-rendering while the user types: never thread a per-save/menu/search/icon/create/
+  active value through, and never hand them an inline arrow — one un-`useCallback`'d prop in `App.tsx`
+  defeats the memo outright. Rows subscribe to a BOOLEAN ("am I active?"), so a tab switch re-renders
+  the two that changed, not all 2,300.
+- **Anything repeated thousands of times carries `content-visibility: auto`** (`.tree-item`,
+  `.pdf-viewer-page`) plus a known box — or all of them lay out and paint on every ancestor's frame.
 - **The two path-keyed position records** (`fileScrollPositions`, `pdfViewPositions`) are held parsed
   in memory via `readRecord`/`flushRecord` in `utils/storage.ts`, keyed by its `scopedKey` — two
   vaults share paths freely. Never pruned (recency capping was **rejected**), so they grow per vault.
@@ -133,8 +135,6 @@ and use it before saying a change works.
   `localStorage` is user-editable and a `NaN` reaches `' '.repeat()` / `Array.slice`. Theme is
   `data-theme` on `<html>` (**absent = dark**); custom accent/code colors are inline `<html>` style
   overrides that intentionally outrank both theme blocks.
-- **File System Access API types** (`showDirectoryPicker`, `queryPermission`, …) are not in stock
-  `lib.dom` — they are augmented via `declare global` in `src/types/index.ts`.
 - **`React.StrictMode` is on** (`main.tsx`), so effects run twice in dev — write effects to tolerate
   it, including the async read-modify-write ones.
 - **ESLint config carries intentional relaxations** (`eslint.config.ts`): `no-unused-vars` ignores

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { clampTabSize } from './editor/lists';
 import { retryMissingAssets } from './editor/imageWidget';
 import { getNotebookExporter, clearNotebookRenderData, moveNotebookRenderData } from './utils/notebookRenderCache';
 import { readLocation, vaultLinkName, writeLocation } from './utils/appUrl';
+import { setActiveFilePath } from './utils/activeFile';
 import {
   ENTRY_STYLE_FILE, LEGACY_STYLE_FILE, emptyEntryStyles, forgetEntry, parseEntryStyles,
   renameEntry, serializeEntryStyles, withEntryStyle, type IconNode,
@@ -47,6 +48,7 @@ import { closeContextMenu, getContextMenu, subscribeContextMenu } from './utils/
 import { getPdfRenderData, clearPdfRenderData, movePdfRenderData } from './utils/pdfRenderCache';
 import './index.css';
 import FileExplorer from './components/FileExplorer';
+import { prefetchPanes } from './components/prefetchPanes';
 import ConfirmDialog from './components/ConfirmDialog';
 import ContextMenu from './components/ContextMenu';
 import EditorPane from './components/EditorPane';
@@ -268,6 +270,10 @@ export default function App() {
   // It is what the file tree highlights and what the graph view centres on;
   // the editor derives its own from the layout, pane by pane.
   const activeFile = activeTab?.file ?? null;
+  /* Published to a store as well as held in state: the file tree reads "am I
+     the active row" from it per row, so switching tabs re-renders the two rows
+     that changed instead of every row in the vault. See utils/activeFile.ts. */
+  useEffect(() => { setActiveFilePath(activeFile?.path ?? null); }, [activeFile]);
 
   // Main pane view ('editor' or 'graph' — the Neural Brain view)
   const [mainView, setMainView] = useState<MainView>('editor');
@@ -502,6 +508,11 @@ export default function App() {
    *  the tree starts re-rendering while the user types. */
   const [searchOpen, setSearchOpen] = useState(false);
   const closeSearch = useCallback(() => setSearchOpen(false), []);
+
+  /** Stable for the app's life. As an inline arrow this handed `FileExplorer` a
+   *  fresh prop on EVERY App render, which defeated its `React.memo` outright —
+   *  the one thing that memo exists to prevent. */
+  const collapseSidebar = useCallback(() => setSidebarCollapsed(true), []);
 
   // Expanded folder paths (persisted via localStorage)
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
@@ -1472,6 +1483,26 @@ export default function App() {
   }, [recentVaults]);
 
   /**
+   * Warm the heavy panes for the kinds of file this vault actually holds.
+   *
+   * Walks `fileTree`, which is already in memory — no disk reads — and only
+   * when the tree changes shape enough to matter. `prefetchPanes` itself is
+   * idle-scheduled and fetches each chunk once, so calling it after every
+   * refresh costs nothing.
+   */
+  useEffect(() => {
+    if (!fileTree.length) return;
+    const kinds = { pdf: false, drawing: false, notebook: false };
+    for (const file of collectFiles(fileTree)) {
+      if (isPdfFile(file.name)) kinds.pdf = true;
+      else if (isNotebookFile(file.name)) kinds.notebook = true;
+      else if (isCanvasFile(file.name)) kinds.drawing = true;
+      if (kinds.pdf && kinds.drawing && kinds.notebook) break;
+    }
+    prefetchPanes(kinds);
+  }, [fileTree]);
+
+  /**
    * Open the file the address bar names, once there is a tree to find it in.
    *
    * Deliberately AFTER the session restore rather than inside it: a link is an
@@ -2074,7 +2105,6 @@ export default function App() {
         <FileExplorer
           rootHandle={rootHandle}
           fileTree={fileTree}
-          activeFilePath={activeFile?.path || null}
           onFileClick={handleFileClick}
           onCreateFile={handleCreateFile}
           onCreateFolder={handleCreateFolder}
@@ -2084,7 +2114,7 @@ export default function App() {
           recentVaultLimit={recentVaultLimit}
           onOpenRecentVault={openRecentVault}
           onForgetRecentVault={forgetRecentVault}
-          onCollapse={() => setSidebarCollapsed(true)}
+          onCollapse={collapseSidebar}
           searchOpen={searchOpen}
           onCloseSearch={closeSearch}
           onTrash={handleTrash}

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -11,6 +11,7 @@ import {
     ancestorsOf, clearCreateRequest, getCreateKindFor, nameForKind, placeholderFor,
     requestCreate, subscribeCreateRequest, type CreateKind,
 } from '../utils/createRequest';
+import { getActiveFilePath } from '../utils/activeFile';
 import { collectFiles } from '../utils/tree';
 import { createVaultTextCache } from '../utils/vaultSearch';
 import type { VaultTextCache } from '../utils/vaultSearch';
@@ -51,7 +52,6 @@ function vaultMenuPosFor(button: HTMLElement): VaultMenuPos {
 interface FileExplorerProps {
     rootHandle: FileSystemDirectoryHandle | null;
     fileTree: FileTreeNode[];
-    activeFilePath: string | null;
     onFileClick: (node: FileTreeNode) => void;
     onCreateFile: (parentHandle: FileSystemDirectoryHandle | null, name: string, parentPath?: string) => void | Promise<void>;
     onCreateFolder: (parentHandle: FileSystemDirectoryHandle | null, name: string) => void | Promise<void>;
@@ -95,7 +95,6 @@ interface FileExplorerProps {
 function FileExplorer({
     rootHandle,
     fileTree,
-    activeFilePath,
     onFileClick,
     onCreateFile,
     onCreateFolder,
@@ -194,25 +193,30 @@ function FileExplorer({
      * With nothing open — or a file whose folder cannot be resolved — the root
      * is still the answer.
      */
-    const createTarget = useMemo(() => {
-        if (!activeFilePath) return '';
-        const node = collectFiles(fileTree).find(f => f.path === activeFilePath);
+    const createTarget = () => {
+        // Read at CLICK time rather than memoized per render: as a memo this
+        // re-ran on every tab switch, which meant subscribing the explorer to
+        // the active file for a value only a button press ever looks at.
+        const active = getActiveFilePath();
+        if (!active) return '';
+        const node = collectFiles(fileTree).find(f => f.path === active);
         if (!node) return '';
         const slash = node.path.lastIndexOf('/');
         return slash === -1 ? '' : node.path.slice(0, slash);
-    }, [activeFilePath, fileTree]);
+    };
 
     /** Open the inline "new file/folder" name box in `createTarget`, leaving
      *  search mode if needed (the box lives in the tree view, which search
      *  temporarily replaces). */
     const startCreateInRoot = (kind: CreateKind) => {
         onCloseSearch();
+        const target = createTarget();
         // Every folder on the way down has to be open, or the row that renders
         // the box is not mounted to see the request. The target opens itself.
-        for (const ancestor of ancestorsOf(createTarget)) {
+        for (const ancestor of ancestorsOf(target)) {
             if (!expandedPaths.has(ancestor)) onToggleExpand(ancestor);
         }
-        requestCreate(createTarget, kind);
+        requestCreate(target, kind);
     };
 
     const handleSearchResult = (node: FileTreeFileNode, range: TextRange | null) => {
@@ -453,7 +457,6 @@ function FileExplorer({
                         <TreeNode
                             key={node.path}
                             node={node}
-                            activeFilePath={activeFilePath}
                             onFileClick={onFileClick}
                             // Straight through — no wrapper. The two that used
                             // to sit here each raised a window.prompt() for the

--- a/src/components/PdfViewer.tsx
+++ b/src/components/PdfViewer.tsx
@@ -1,14 +1,10 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as pdfjs from 'pdfjs-dist';
 import type { PDFDocumentProxy, PDFPageProxy, RenderTask } from 'pdfjs-dist';
-import workerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 import { readRecord, flushRecord, scopedKey } from '../utils/storage';
 import { readPageLinks, resolveDestination } from '../utils/pdfLinks';
+import { pdfWorker } from '../utils/pdfWorker';
 import type { PdfLink, PdfLinkTarget } from '../utils/pdfLinks';
-
-// Same assignment as utils/pdfAnnotation.ts — whichever module loads first
-// wins, and both hand pdf.js the identical bundled worker URL.
-pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
 
 /**
  * The view half of a PDF: a pdf.js-rendered continuous scroll of pages.
@@ -77,12 +73,13 @@ interface DocState {
 interface PageState {
     pagePromise?: Promise<PDFPageProxy>;
     renderTask?: RenderTask;
-    /** Scale of the bitmap currently in this page's canvas. */
-    renderedScale?: number;
-    /** Scale the in-flight render is producing (to avoid cancelling it needlessly). */
-    renderingScale?: number;
-    /** Latest scale the window pass asked for; the render loop chases it. */
-    wantScale?: number;
+    /** What the bitmap in this page's canvas actually shows. */
+    rendered?: RenderTarget;
+    /** What the in-flight render will produce, so the window pass can tell
+     *  whether cancelling it would gain anything. */
+    rendering?: RenderTarget;
+    /** Latest ask from the window pass; the render loop chases it. */
+    want?: RenderTarget;
     /** False once evicted — tells an in-flight render loop to stop. */
     wantRender?: boolean;
     /** A render loop is currently running for this page. */
@@ -102,6 +99,10 @@ const PAD_V = 20;
 /** Gap between pages, px. */
 const PAGE_GAP = 14;
 /** Horizontal breathing room subtracted from the container for fit-width. */
+/** Matches the zoom gesture's own settle: long enough that an animated resize
+ *  re-fits once at the size it lands on, short enough to feel immediate. */
+const RESIZE_SETTLE_MS = 180;
+
 const SIDE_GUTTER = 28;
 /** Render canvases this many pages beyond the visible range. */
 const RENDER_AHEAD = 1;
@@ -124,6 +125,144 @@ const CLEANUP_BEYOND = 12;
 const TEXT_EAGER_LIMIT = 300;
 const MIN_ZOOM = 0.4;
 const MAX_ZOOM = 4;
+
+/**
+ * Device-pixel ceiling for one page's bitmap.
+ *
+ * MEASURED: without it, this 40-page document at 4x zoom held two canvases of
+ * 9440x12216 — 231 megapixels, ~923MB of backing store — and zooming back out
+ * of it ran at 7fps with 1.3s of blocked main thread. The canvas grew with the
+ * zoom even though the viewport only ever showed a sliver of it.
+ *
+ * 2^24 px is ~67MB a page, in the same range as pdf.js's own viewer (its
+ * `maxCanvasPixels` default is 2^25). Past the ceiling a page is rendered A
+ * BAND AT A TIME rather than rendered softer — zoom exists to read fine print,
+ * so buying speed with sharpness would defeat the gesture. See pageRegion.
+ */
+const MAX_CANVAS_PIXELS = 2 ** 24;
+
+/** Backing-store multiplier. Capped at 2: past it the sharpness gain is
+ *  invisible but the bitmap cost doubles again. */
+const canvasDpr = () => Math.min(Math.max(window.devicePixelRatio || 1, 1), 2);
+
+/** Where every page sits, for one (document, container width, zoom). */
+interface Layout {
+    gen: number;
+    /** pdf.js render scale: PDF points → CSS pixels. */
+    scale: number;
+    pages: Array<{ w: number; h: number }>;
+    /** Each page's top edge in scroller content coordinates. */
+    tops: number[];
+    maxPageW: number;
+}
+
+/** A band of one page, in that page's own CSS pixels at the current layout
+ *  scale — the origin is the page's top-left corner, not the document's. */
+interface PageRect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
+/** One rasterization request, and everything needed to decide whether a bitmap
+ *  already in hand answers it. */
+interface RenderTarget {
+    scale: number;
+    /** The band to rasterize; `null` for the whole page, which is the case at
+     *  every zoom that fits inside MAX_CANVAS_PIXELS. */
+    rect: PageRect | null;
+    /** The strictly visible part of it, which is what must end up painted. */
+    need: PageRect | null;
+    /** `rect` pulled in by half its own margin (except where it already meets
+     *  a page edge): once the visible band escapes THIS, re-rendering buys
+     *  something. Deflating rather than using `rect` itself is what keeps a
+     *  scroll from re-rendering the instant it moves one pixel. */
+    trigger: PageRect | null;
+}
+
+const contains = (outer: PageRect, inner: PageRect): boolean =>
+    inner.x >= outer.x - 0.5 && inner.y >= outer.y - 0.5
+    && inner.x + inner.w <= outer.x + outer.w + 0.5
+    && inner.y + inner.h <= outer.y + outer.h + 0.5;
+
+/** Would the bitmap `have` describes still answer `want`? */
+function satisfies(have: RenderTarget | undefined, want: RenderTarget): boolean {
+    if (!have || have.scale !== want.scale) return false;
+    // The whole page is wanted: only a whole-page bitmap will do, or zooming
+    // back out would leave a band stretched across the page.
+    if (want.rect === null) return have.rect === null;
+    // A whole-page bitmap covers any band of it.
+    if (have.rect === null) return true;
+    return have.trigger !== null && want.need !== null && contains(have.trigger, want.need);
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+
+/**
+ * Which band of page `i` to rasterize, given where the reader is looking.
+ *
+ * Returns whole-page targets while the page fits the bitmap budget — the
+ * ordinary case, and the one where nothing about scrolling should re-render.
+ * Past it, the band is the visible strip grown by as much margin as the budget
+ * still affords, so scrolling at zoom moves around inside paint already done.
+ */
+function pageRegion(L: Layout, el: HTMLElement, i: number): Omit<RenderTarget, 'scale'> {
+    const { w, h } = L.pages[i];
+    const dpr = canvasDpr();
+    if (w * h * dpr * dpr <= MAX_CANVAS_PIXELS) return { rect: null, need: null, trigger: null };
+
+    // Pages are centred in the inner column, so the page's own origin sits at
+    // `left` in scroller content coordinates.
+    const left = (Math.max(el.clientWidth, L.maxPageW) - w) / 2;
+    const x = clamp(el.scrollLeft - left, 0, w);
+    const y = clamp(el.scrollTop - L.tops[i], 0, h);
+    const need: PageRect = {
+        x,
+        y,
+        // At least a pixel: a page that is in the render window but not yet on
+        // screen has an empty intersection, and a zero-sized canvas is invalid.
+        w: Math.max(1, clamp(el.scrollLeft - left + el.clientWidth, 0, w) - x),
+        h: Math.max(1, clamp(el.scrollTop - L.tops[i] + el.clientHeight, 0, h) - y),
+    };
+
+    // Grow it as far as the budget allows: solve (need.w + 2m)(need.h + 2m) =
+    // budget for the margin m. `room` floors at zero for the (tiny viewport,
+    // huge dpr) case where the visible strip alone is already over budget —
+    // then the band is the strip, which is the least that can be rendered.
+    const budget = MAX_CANVAS_PIXELS / (dpr * dpr);
+    const room = Math.max(0, budget - need.w * need.h);
+    const span = need.w + need.h;
+    const m = (Math.sqrt(span * span + 4 * room) - span) / 4;
+    const rx = Math.max(0, need.x - m);
+    const ry = Math.max(0, need.y - m);
+    const rect: PageRect = {
+        x: rx,
+        y: ry,
+        w: Math.min(w, need.x + need.w + m) - rx,
+        h: Math.min(h, need.y + need.h + m) - ry,
+    };
+
+    // Half the margin back off each side that is not already a page edge —
+    // which keeps `need` inside `trigger` the moment the render lands, so this
+    // can never ask for a re-render of what was just rendered.
+    const edge = (lo: number, hi: number, limit: number) =>
+        [lo <= 0.5 ? lo : lo + m / 2, hi >= limit - 0.5 ? hi : hi - m / 2] as const;
+    const [tx0, tx1] = edge(rect.x, rect.x + rect.w, w);
+    const [ty0, ty1] = edge(rect.y, rect.y + rect.h, h);
+    const trigger: PageRect = { x: tx0, y: ty0, w: tx1 - tx0, h: ty1 - ty0 };
+    return { rect, need, trigger };
+}
+
+/** Put the canvas where its bitmap belongs: filling the page, or pinned over
+ *  the band it was rendered for. */
+function placeCanvas(canvas: HTMLCanvasElement, rect: PageRect | null): void {
+    const s = canvas.style;
+    s.left = rect ? `${rect.x}px` : '';
+    s.top = rect ? `${rect.y}px` : '';
+    s.width = rect ? `${rect.w}px` : '';
+    s.height = rect ? `${rect.h}px` : '';
+}
 
 // Rounded finely (not to 2dp): a pinch step near MIN_ZOOM is ~0.4%, and a
 // coarser rounding would swallow it and leave the gesture stuck.
@@ -166,6 +305,10 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
     const [docState, setDocState] = useState<DocState | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [containerWidth, setContainerWidth] = useState(0);
+    /** Read by the ResizeObserver, which is created once and must not close over
+     *  a stale width when deciding "is this the first measurement". */
+    const containerWidthRef = useRef(0);
+    useEffect(() => { containerWidthRef.current = containerWidth; }, [containerWidth]);
 
     const rootRef = useRef<HTMLDivElement | null>(null);
     const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -241,7 +384,7 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
         const pageStates = pageStatesRef.current;
         // pdf.js takes ownership of (and detaches) the buffer it's handed —
         // always give it a copy so `data` stays readable for the next load.
-        const task = pdfjs.getDocument({ data: data.slice() });
+        const task = pdfjs.getDocument({ data: data.slice(), worker: pdfWorker() });
 
         (async () => {
             try {
@@ -287,18 +430,38 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
     }, [data]);
 
     // ── Fit-width layout ─────────────────────────────────────────────────────
+    /*
+     * The observed width is COALESCED, exactly as the pinch-zoom gesture below
+     * coalesces its own: committing it re-fits the document and restarts the
+     * rasterization of every windowed page, and a resize does not arrive once —
+     * it arrives on every frame of whatever is animating.
+     *
+     * The sidebar's 150ms width transition is the case that made this matter:
+     * collapsing the drawer replayed a full re-fit ~9 times, measured at ~500ms
+     * of blocked main thread for a gesture that changes nothing about the
+     * document. Pages are centred in the scroller, so they simply re-centre
+     * while the burst is in flight and re-fit once it quiets.
+     *
+     * The FIRST measurement commits immediately: there is no layout yet, and
+     * making the reader wait 180ms to see page one would be a worse trade than
+     * the one this is making.
+     */
     useEffect(() => {
         const el = scrollRef.current;
         if (!el) return;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        const commit = (w: number) => setContainerWidth(prev => (Math.abs(prev - w) < 1 ? prev : w));
         const ro = new ResizeObserver(entries => {
             const w = Math.round(entries[0].contentRect.width);
-            setContainerWidth(prev => (Math.abs(prev - w) < 1 ? prev : w));
+            if (containerWidthRef.current <= 0) { commit(w); return; }
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(() => { timer = null; commit(w); }, RESIZE_SETTLE_MS);
         });
         ro.observe(el);
-        return () => ro.disconnect();
+        return () => { ro.disconnect(); if (timer) clearTimeout(timer); };
     }, []);
 
-    const layout = useMemo(() => {
+    const layout = useMemo<Layout | null>(() => {
         if (!docState || containerWidth <= 0) return null;
         const avail = Math.max(120, containerWidth - SIDE_GUTTER * 2);
         const maxW = Math.max(...docState.dims.map(d => d.w));
@@ -335,6 +498,7 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
         if (canvas && canvas.width > 0) {
             canvas.width = 0;
             canvas.height = 0;
+            placeCanvas(canvas, null);
         }
     }, []);
 
@@ -482,44 +646,69 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
         return st.linksPromise;
     }, [getState, getPage, createLinkElement]);
 
-    /** Render one page's canvas, chasing wantScale until it matches (a zoom
-     *  mid-render cancels the task and the loop goes again at the new scale). */
+    /** Render one page's canvas, chasing `st.want` until the bitmap answers it
+     *  (a zoom or a scroll mid-render cancels the task and the loop goes again
+     *  against the new target). */
     const renderLoop = useCallback(async (i: number, st: PageState) => {
         st.busy = true;
         const gen = docGenRef.current;
         try {
-            while (st.wantRender && st.wantScale !== undefined && st.renderedScale !== st.wantScale) {
-                const scale = st.wantScale;
+            while (st.wantRender && st.want && !satisfies(st.rendered, st.want)) {
+                const target = st.want;
                 const page = await getPage(i);
                 if (docGenRef.current !== gen || !st.wantRender) return;
                 const canvas = canvasElsRef.current[i];
                 if (!canvas) return;
 
-                const vp = page.getViewport({ scale });
-                // Cap the backing-store multiplier: past 2x the sharpness gain is
-                // invisible but the bitmap cost doubles again.
-                const dpr = Math.min(Math.max(window.devicePixelRatio || 1, 1), 2);
-                canvas.width = Math.max(1, Math.floor(vp.width * dpr));
-                canvas.height = Math.max(1, Math.floor(vp.height * dpr));
-                const ctx = canvas.getContext('2d');
+                const { rect } = target;
+                const vp = page.getViewport({ scale: target.scale });
+                const dpr = canvasDpr();
+                const cw = Math.max(1, Math.floor((rect ? rect.w : vp.width) * dpr));
+                const ch = Math.max(1, Math.floor((rect ? rect.h : vp.height) * dpr));
+
+                // Rasterize OFF-SCREEN once there is something on screen worth
+                // keeping: sizing a canvas wipes it, so rendering in place left
+                // the page blank white for the length of every zoom step and,
+                // now that a scroll at zoom can re-render, for those too. The
+                // spare bitmap is skipped on a page's first render, where there
+                // is nothing to preserve and it would only double the cold cost.
+                const work = st.rendered ? document.createElement('canvas') : canvas;
+                work.width = cw;
+                work.height = ch;
+                const ctx = work.getContext('2d');
                 if (!ctx) return;
 
                 const task = page.render({
-                    canvas,
+                    canvas: work,
                     canvasContext: ctx,
                     viewport: vp,
-                    transform: dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined,
+                    // Band rendering is a translate on top of the dpr scale: the
+                    // viewport stays the whole page, and the canvas catches the
+                    // part of it that starts at the band's corner.
+                    transform: rect
+                        ? [dpr, 0, 0, dpr, -rect.x * dpr, -rect.y * dpr]
+                        : (dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined),
                 });
                 st.renderTask = task;
-                st.renderingScale = scale;
+                st.rendering = target;
                 try {
                     await task.promise;
-                    st.renderedScale = scale;
+                    if (work !== canvas) {
+                        canvas.width = cw;
+                        canvas.height = ch;
+                        canvas.getContext('2d')?.drawImage(work, 0, 0);
+                    }
+                    placeCanvas(canvas, rect);
+                    st.rendered = target;
                 } catch (err) {
                     if (!(err instanceof pdfjs.RenderingCancelledException)) throw err;
                 } finally {
                     st.renderTask = undefined;
-                    st.renderingScale = undefined;
+                    st.rendering = undefined;
+                    if (work !== canvas) {
+                        work.width = 0;
+                        work.height = 0;
+                    }
                 }
                 if (docGenRef.current !== gen) return;
             }
@@ -531,26 +720,27 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
             st.busy = false;
             if (!st.wantRender) {
                 clearCanvas(i);
-                st.renderedScale = undefined;
+                st.rendered = undefined;
             }
         }
     }, [getPage, ensureText, ensureLinks, clearCanvas]);
 
     const ensurePage = useCallback((i: number) => {
         const L = layoutRef.current;
-        if (!L) return;
+        const el = scrollRef.current;
+        if (!L || !el) return;
         const st = getState(i);
-        st.wantScale = L.scale;
+        st.want = { scale: L.scale, ...pageRegion(L, el, i) };
         st.wantRender = true;
         // Back in the window — eligible to be released again once it leaves.
         st.cleaned = false;
         if (st.busy) {
-            // Already rendering: if it's producing a stale scale, cancel so the
-            // loop re-runs at the right one.
-            if (st.renderTask && st.renderingScale !== st.wantScale) st.renderTask.cancel();
+            // Already rendering: if what it will produce no longer answers the
+            // ask, cancel so the loop re-runs against the new one.
+            if (st.renderTask && !satisfies(st.rendering, st.want)) st.renderTask.cancel();
             return;
         }
-        if (st.renderedScale === st.wantScale) {
+        if (satisfies(st.rendered, st.want)) {
             void ensureText(i);
             void ensureLinks(i);
             return;
@@ -560,12 +750,12 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
 
     const evictPage = useCallback((i: number) => {
         const st = pageStatesRef.current.get(i);
-        if (!st || (!st.wantRender && st.renderedScale === undefined)) return;
+        if (!st || (!st.wantRender && !st.rendered)) return;
         st.wantRender = false;
         st.renderTask?.cancel();
         if (!st.busy) {
             clearCanvas(i);
-            st.renderedScale = undefined;
+            st.rendered = undefined;
         }
     }, [clearCanvas]);
 

--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -8,6 +8,7 @@ import {
 import { setDraggedNode, takeDraggedNode } from '../utils/treeDrag';
 import { isTabDrag } from '../utils/tabDrag';
 import { openContextMenu } from '../utils/contextMenu';
+import { isActiveFilePath, subscribeActiveFile } from '../utils/activeFile';
 import LucideGlyph from './LucideGlyph';
 import { getEntryStyle, getEntryStyles, subscribeEntryStyles } from '../utils/entryStyleStore';
 import { entryColorVar, type IconNode } from '../utils/entryStyle';
@@ -16,7 +17,6 @@ import type { FileTreeNode } from '../types';
 
 interface TreeNodeProps {
     node: FileTreeNode;
-    activeFilePath: string | null;
     onFileClick: (node: FileTreeNode) => void;
     /** Create a file called `name` inside `handle`, which sits at `path`.
      *  THREE arguments, matching App.handleCreateFile: it opens the new file
@@ -46,7 +46,7 @@ interface TreeNodeProps {
 }
 
 
-function TreeNode({ node, activeFilePath, onFileClick, onCreateFile, onCreateFolder, onTrash, onOpenAsVault, onStyleEntry, expandedPaths, onToggleExpand, onMoveFile, onRenameFile, onImportFiles, depth = 0 }: TreeNodeProps) {
+function TreeNode({ node, onFileClick, onCreateFile, onCreateFolder, onTrash, onOpenAsVault, onStyleEntry, expandedPaths, onToggleExpand, onMoveFile, onRenameFile, onImportFiles, depth = 0 }: TreeNodeProps) {
     /* This row's own icon and colour, read from the store rather than taken as
        a prop — see utils/folderStyleStore.ts. The snapshot is the STORED object,
        so a row whose folder was not the one that changed sees an unchanged
@@ -60,7 +60,13 @@ function TreeNode({ node, activeFilePath, onFileClick, onCreateFile, onCreateFol
        for one folder's change. This row already re-renders when its OWN style
        does, which is the only time the artwork it needs can have arrived. */
     const customIconNodes = style?.icon ? getEntryStyles().icons[style.icon] : undefined;
-    const isActive = node.kind === 'file' && node.path === activeFilePath;
+    /* Subscribed as a BOOLEAN, not taken as a prop. `activeFilePath` used to
+       travel the whole recursion, so switching tabs changed a prop on every row
+       and re-rendered all of them to move one highlight. See utils/activeFile.ts. */
+    const isActive = useSyncExternalStore(
+        subscribeActiveFile,
+        useCallback(() => node.kind === 'file' && isActiveFilePath(node.path), [node.kind, node.path]),
+    );
     const paddingLeft = 12 + depth * 16;
     const expanded = expandedPaths.has(node.path);
     const [dragOver, setDragOver] = useState(false);
@@ -511,7 +517,6 @@ function TreeNode({ node, activeFilePath, onFileClick, onCreateFile, onCreateFol
                         <MemoTreeNode
                             key={child.path}
                             node={child}
-                            activeFilePath={activeFilePath}
                             onFileClick={onFileClick}
                             onCreateFile={onCreateFile}
                             onCreateFolder={onCreateFolder}

--- a/src/components/prefetchPanes.ts
+++ b/src/components/prefetchPanes.ts
@@ -1,0 +1,69 @@
+// Warm the heavy panes before they are clicked.
+//
+// A PDF, a drawing and a notebook each live behind `React.lazy`, which is what
+// keeps pdf.js (~450kB) and tldraw (~1.7MB) out of a markdown-only session's
+// bundle. The cost of that is paid on the FIRST click: measured at ~0.8s for a
+// PDF and ~1.2s for a drawing, nearly all of it fetching and parsing the chunk
+// rather than doing anything with the document.
+//
+// So fetch them while nothing is happening instead. Two rules keep this from
+// undoing the split it is built on top of:
+//
+//   · ONLY WHAT THE VAULT ACTUALLY CONTAINS. A vault of pure markdown fetches
+//     nothing, which is the case the code splitting exists for. Opening a vault
+//     with one `.pdf` in it warms pdf.js and leaves tldraw alone.
+//   · ONLY WHEN IDLE, and never before the app has drawn. `requestIdleCallback`
+//     yields to anything the reader is doing; this is a nice-to-have that must
+//     never compete with a keystroke.
+//
+// The import specifiers must match the ones `EditorPane`/`DocumentPane` use, or
+// the bundler emits a second copy of each chunk instead of warming theirs.
+
+export interface CanvasKinds {
+    pdf: boolean;
+    drawing: boolean;
+    notebook: boolean;
+}
+
+/** Each chunk is fetched at most once per session, whatever asks for it. */
+const started = new Set<string>();
+
+function warm(key: string, load: () => Promise<unknown>): void {
+    if (started.has(key)) return;
+    started.add(key);
+    // A failed prefetch is not an error the reader should ever see: the real
+    // import on click will surface anything that actually matters.
+    load().catch(() => started.delete(key));
+}
+
+/**
+ * Fetch the chunks this vault will need, once the browser is idle.
+ *
+ * Safe to call repeatedly — on every tree refresh, say. Each chunk is warmed
+ * once, and a vault holding none of these kinds does nothing at all.
+ */
+export function prefetchPanes(kinds: CanvasKinds): void {
+    if (!kinds.pdf && !kinds.drawing && !kinds.notebook) return;
+
+    const run = () => {
+        // PdfPane pulls pdf.js; the annotate canvas and its tldraw are left for
+        // the moment someone actually annotates, since reading is the common case.
+        // Starting the shared worker here too takes the ~1MB worker boot off the
+        // first click — dynamically, or pdf.js would land in the main bundle.
+        if (kinds.pdf) {
+            warm('pdf', () => import('./PdfPane'));
+            warm('pdf-worker', () => import('../utils/pdfWorker').then(m => { m.pdfWorker(); }));
+        }
+        // A notebook IS a tldraw canvas, so either kind warms the big one.
+        if (kinds.drawing) warm('drawing', () => import('./DrawingPane'));
+        if (kinds.notebook) warm('notebook', () => import('./NotebookPane'));
+    };
+
+    const idle = (window as unknown as {
+        requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+    }).requestIdleCallback;
+    // Safari has no requestIdleCallback; a timeout is a fine stand-in for
+    // something whose only requirement is "not right now".
+    if (idle) idle(run, { timeout: 4000 });
+    else setTimeout(run, 1500);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -505,7 +505,20 @@ body {
 /* =============================================================
    Tree Items
    ============================================================= */
+/* SKIP THE ROWS NOBODY IS LOOKING AT.
+   A browsed-open vault is thousands of rows, and every one of them was being
+   laid out and painted — on each frame of the sidebar's 150ms width transition,
+   which is what made collapsing it feel broken (measured: ~210ms of blocked
+   main thread to move a drawer, with zero React work behind it).
+
+   `content-visibility: auto` lets the browser skip layout and paint for rows
+   outside the scroller, and the intrinsic size makes that free of side effects
+   here: rows are a FIXED height, so the scrollbar geometry it substitutes is
+   exactly what the real row would have produced. Ctrl+F still finds them —
+   `auto` keeps content searchable, unlike `hidden`. */
 .tree-item {
+  content-visibility: auto;
+  contain-intrinsic-size: auto var(--nav-item-height);
   display: flex;
   align-items: center;
   height: var(--nav-item-height);
@@ -1902,11 +1915,23 @@ body.is-resizing-panes * {
   margin-right: auto;
   background: #fff;
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.35);
+  /* Skip the pages nobody is looking at. A zoom step restyles every text-layer
+     span and repaints the whole column, so a 40-page document paid 40 pages of
+     style, layout and compositor commit to change what two of them show —
+     measured at 61ms of Commit plus 68ms in the keydown, per step. No
+     contain-intrinsic-size: each page carries an explicit width/height from the
+     layout, so a skipped one still reserves exactly the right box, and
+     find-in-page still reaches the text inside it. */
+  content-visibility: auto;
 }
 
+/* Top/left rather than `inset: 0`, because at high zoom the canvas holds one
+   BAND of the page and is pinned over it with inline left/top/width/height
+   (see MAX_CANVAS_PIXELS); a `right`/`bottom` here would only be ignored. */
 .pdf-viewer-page > canvas {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   display: block;

--- a/src/utils/activeFile.ts
+++ b/src/utils/activeFile.ts
@@ -1,0 +1,39 @@
+// Which document is on screen, as an external store.
+//
+// A PROP FOR THIS IS THE EXPENSIVE KIND. `activeFilePath` travelled the whole
+// TreeNode recursion, so switching tabs changed a prop on EVERY row and
+// re-rendered all of them — measured at 440 rows of work to move a highlight
+// between two of them, and a vault of 2,300 rows pays that on every tab click.
+// The memo on TreeNode could not help: the prop really had changed.
+//
+// Read as a BOOLEAN per row instead. `useActiveFile(path)` answers "is this row
+// the active one", so a switch changes the snapshot for exactly the two rows
+// whose answer moved and every other row's `useSyncExternalStore` sees `false`
+// before and `false` after. Same reasoning as utils/contextMenu.ts, and the
+// same shape.
+
+let activePath: string | null = null;
+const listeners = new Set<() => void>();
+
+export function setActiveFilePath(path: string | null): void {
+    if (path === activePath) return;
+    activePath = path;
+    for (const listener of listeners) listener();
+}
+
+/** The open document's vault path, for code that wants the value rather than a
+ *  subscription — read at the moment it is needed (a click), not per render. */
+export function getActiveFilePath(): string | null {
+    return activePath;
+}
+
+export function subscribeActiveFile(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => { listeners.delete(listener); };
+}
+
+/** A boolean snapshot, which is what keeps a switch from re-rendering the tree:
+ *  only the rows whose answer actually changed see a different value. */
+export function isActiveFilePath(path: string): boolean {
+    return activePath === path;
+}

--- a/src/utils/pdfAnnotation.ts
+++ b/src/utils/pdfAnnotation.ts
@@ -20,10 +20,7 @@
 
 import * as pdfjs from 'pdfjs-dist';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
-import workerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
-
-// Vite bundles the worker as a separate chunk; hand pdf.js its real URL.
-pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+import { pdfWorker } from './pdfWorker';
 
 // Writing lives in utils/pdfBuild.ts (pdf-lib only, so a worker can load it).
 // The shared names come from pdfFormat.ts rather than from pdfBuild directly —
@@ -75,7 +72,7 @@ export interface AnnotatedPdfContents {
 async function withPdf<T>(bytes: Uint8Array, read: (doc: PDFDocumentProxy) => Promise<T>): Promise<T> {
     // pdf.js takes ownership of (and detaches) the buffer it is handed, which
     // would corrupt a caller still holding the same bytes. Always give it a copy.
-    const task = pdfjs.getDocument({ data: bytes.slice() });
+    const task = pdfjs.getDocument({ data: bytes.slice(), worker: pdfWorker() });
     try {
         return await read(await task.promise);
     } finally {
@@ -232,7 +229,7 @@ export interface PdfPageSource {
 export async function openPdfPages(original: Uint8Array): Promise<PdfPageSource> {
     // Not withPdf(): the document must outlive this call so pages can be
     // rasterized on demand. close() is the caller's responsibility.
-    const task = pdfjs.getDocument({ data: original.slice() });
+    const task = pdfjs.getDocument({ data: original.slice(), worker: pdfWorker() });
     const doc = await task.promise;
 
     const sizes: PdfPageSize[] = [];

--- a/src/utils/pdfWorker.ts
+++ b/src/utils/pdfWorker.ts
@@ -1,0 +1,38 @@
+// One pdf.js worker for the whole app.
+//
+// pdf.js spawns a worker PER `getDocument` unless it is handed one, and a
+// loading task only tears down a worker it created itself — so passing a shared
+// one is both safe and the whole fix. Opening a single PDF used to start two:
+// PdfPane probes the file's role (attachments) before it knows which view to
+// show, then the viewer opens the same bytes again. Each boot loads and
+// compiles ~1MB of worker script before a byte of the document is read.
+//
+// One worker is also what pdf.js's own viewer does. The cost is that documents
+// share a thread, which for an app that shows one or two PDFs at a time is far
+// cheaper than the boots it replaces.
+
+import * as pdfjs from 'pdfjs-dist';
+import workerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
+
+// Vite bundles the worker as a separate chunk; hand pdf.js its real URL. This
+// module is the one place that says so — importing it is how the PDF modules
+// get the assignment.
+pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+
+type PdfWorker = InstanceType<typeof pdfjs.PDFWorker>;
+
+let shared: PdfWorker | null = null;
+
+/**
+ * The shared worker, started on first use.
+ *
+ * Pass it as `worker` to every `getDocument` call: without it pdf.js creates
+ * its own and `loadingTask.destroy()` takes it down again, so nothing is ever
+ * reused. Re-created if it was ever destroyed, which only a teardown race can
+ * do — a dead worker would fail every subsequent load with "Worker was
+ * destroyed".
+ */
+export function pdfWorker(): PdfWorker {
+    if (!shared || shared.destroyed) shared = new pdfjs.PDFWorker();
+    return shared;
+}


### PR DESCRIPTION
Four separate regressions had accumulated, each cheap on a small vault and ruinous on a real one. All numbers below are measured on a 2,283-row vault and a 40-page PDF, on the production build at 4x CPU throttle, in-page (an earlier harness that drove the DOM from Playwright was measuring its own actionability scan, not the app).

## The sidebar and tab switching

Three causes, all in the same path:

- `App.tsx` passed `onCollapse` as an inline arrow, so `FileExplorer` got a fresh prop on every App render and its `React.memo` never once held.
- `activeFilePath` travelled the whole `TreeNode` recursion, so switching tabs changed a prop on **every** row and re-rendered all of them to move one highlight. It is now an external store a row reads as a boolean (`utils/activeFile.ts`), the same shape as the existing context-menu and entry-style stores.
- Every row was laid out and painted on each frame of the sidebar's 150ms width transition. `content-visibility: auto` skips the ones off screen.

| | before | after |
|---|---|---|
| sidebar collapse/expand (heavy tabs) | 583/640 ms, ~500 blocked | 231/233 ms, **0 blocked** |
| switch note tab | 226 ms, 152 blocked | 47 ms, **0 blocked** |
| switch to a PDF tab | 311 ms, 200 blocked | 67 ms, **0 blocked** |

## PDF zoom

A page's canvas grew with the zoom even though the viewport only ever showed a sliver of it. At 4x: two canvases of 9440x12216, **231 megapixels, ~923MB** of backing store. A page's bitmap is now capped, and past the cap the page renders **one band at a time** — the visible strip grown by as much margin as the budget still affords.

Capping the render *scale* instead would have been ten lines and is the wrong trade: zoom exists to read fine print, so going soft at high zoom defeats the gesture. Verified sharp at 400%, including scrolling across a page boundary.

Sizing a canvas wipes it, so band re-renders would have flashed the page white. They now rasterize off-screen and blit, which also removes the flash from ordinary zoom steps, where it was always there.

| | before | after |
|---|---|---|
| zoom out 400%->40% | **7 fps**, 1296 ms blocked | 60 fps, **0 blocked** |
| zoom in 100%->400% | 31 fps, 955 ms worst frame | 55 fps, 121 ms |
| canvas memory at 4x | 923 MB | 63 MB, flat with zoom |
| fast scroll / scroll at zoom / page jump | | 56-61 fps, **0 blocked** |

## Two pdf.js workers per click

pdf.js spawns a worker per `getDocument` unless handed one, and opening a PDF did two: `PdfPane` probes the file's role before it knows which view to show, then `PdfViewer` opens the same bytes again. Each boot loads and compiles ~1MB of worker script first. One shared worker now, verified by counting `new Worker`: zero created per PDF opened.

## Cold panes

pdf.js and tldraw sit behind `React.lazy` to keep them out of a markdown-only bundle, and the whole cost lands on the first click. `prefetchPanes` warms them at idle, gated on the kinds the open vault actually holds, so a markdown-only vault still fetches nothing. Worth little on localhost where the fetch is free; on the deployed site it is the difference between downloading 1.7MB of tldraw at click time and none.

Blocked main-thread time is now zero on every interactive path. The sidebar's remaining ~230 ms is the CSS transition itself.

## One thing worth a second look

`content-visibility: auto` on `.pdf-viewer-page` is something the `pdf-and-drawings` skill had already tried and **rejected**. That rejection was measured against *memory*, where it is still right (533.8MB -> 542.1MB; Blink does not tear down layout structures already built). Against *per-frame cost* it is decisive, because a zoom step changes `--scale-factor` and so restyles every text-layer span in the document. Both measurements now sit side by side in the skill, so this does not get reverted for the reason it was once refused.

Since those eager text layers exist for Ctrl+F, that was A/B'd rather than assumed: with and without, find lands on the same page at the same rect.

## Verification

`typecheck`, `lint`, `build` clean. E2E: `pdfopen`, `inplace`, `notebook`, `pages`, `urls`, `penmemory`, `createin`, `folders`, `entries` all pass, re-run after rebasing onto #3. `roundtrip` passes its real assertions and dies on a stale final step that clicks a file the test itself renamed — a pre-existing harness bug, not touched here.