### PR TITLE
Make ink keep up with the pen

### DIFF
--- a/.agents/skills/pdf-and-drawings/SKILL.md
+++ b/.agents/skills/pdf-and-drawings/SKILL.md
@@ -170,6 +170,38 @@ requires reading it.
   persists it per vault path to localStorage `pdfViewPositions` (debounced); geometry changes (zoom,
   resize, reload, the byte-swap after an annotated save) re-anchor scroll from that record.
 
+## The pen is a forked draw shape — `components/tightDrawShape.tsx`
+
+All three canvases pass `shapeUtils={CANVAS_SHAPE_UTILS}`, which substitutes tldraw's draw shape (same
+`type: 'draw'`, so `mergeArraysAndReplaceDefaults` swaps rather than adds). It exists for ONE number.
+
+- **`streamline` is the only thing that decides how far ink trails the pen**, and tldraw does not
+  expose it: `getFreehandOptions` is module-private in `lib/shapes/draw/getPath.js`, called from
+  DrawShapeUtil's own methods, taking nothing from the editor. There is no hook. Re-rendering the
+  shape is the only route.
+- **Measure it on the CENTRELINE, never the rendered outline.** `getStrokePoints` gives the smoothed
+  centreline before any width is applied; comparing its last point to the last raw input point is the
+  honest number. Measuring the outline's leading edge instead conflates tracking with stroke
+  thickness — a fatter stroke reaches nearer the nib while tracking no better, which is exactly how an
+  earlier attempt "proved" a 2x win that was not there. Width has *zero* effect on tracking: identical
+  lag at 3, 4.6, 6 and 10px.
+- Measured at 12px between input points: streamline 0.64 → 7.79px behind the pen, 0.62 → 7.05px,
+  0.40 → 2.10px, **0.01 (ours) → 0.00px**.
+- **`dash` stays `'solid'`** (pinned in `canvasPen.ts`) because it is what keeps stroke width even.
+  tldraw only consults `isPen` when dash is `'draw'`, so a stylus never reaches `realPressureSettings`
+  here — that branch buys 0.74px and costs pressure-varying width.
+- **Four methods are overridden and every one of them matters**: `component` (the ink), `getGeometry`
+  (or clicking a stroke misses it by ~5px), `getIndicatorPath` (or the selection outline floats beside
+  the ink), and `toSvg` (or the notebook's PDF export quietly uses tldraw's smoothing and differs from
+  the screen). Each delegates to `super` unless `dash === 'solid'`, so what is owned across upgrades is
+  one branch, not a renderer.
+- **`components/PenDevPanel.tsx` is how this number gets chosen** — dev-only, portalled to `<body>`,
+  slider plus presets, applying to the NEXT stroke so a canvas can hold strokes at several settings
+  side by side. It is gated on `import.meta.env.DEV` and carries its own CSS in a `<style>` tag rather
+  than `index.css`, so markup, logic and styles all leave the production build together (verified by
+  grepping `dist`). **Reach for it before touching `PEN_STREAMLINE`**: the arithmetic predicted 0.35-0.45
+  would be the floor and drawing on a real tablet disproved it.
+
 ## Panes
 
 - **One `PdfPane` is mounted per open PDF tab** (EditorPane maps over PDF tabs), hidden via

--- a/src/components/DrawingPane.tsx
+++ b/src/components/DrawingPane.tsx
@@ -3,7 +3,7 @@ import { Tldraw, getSnapshot } from 'tldraw';
 import type { Editor, TLEditorSnapshot } from 'tldraw';
 import 'tldraw/tldraw.css';
 import type { Theme } from '../types';
-import { CANVAS_COMPONENTS, applyCanvasUi, applyPenDefaults, readCanvasUi, type CanvasUiState } from './canvasPen';
+import { CANVAS_COMPONENTS, CANVAS_SHAPE_UTILS, applyCanvasUi, applyPenDefaults, readCanvasUi, type CanvasUiState } from './canvasPen';
 import { subscribePenScale } from '../utils/penStyle';
 
 interface DrawingPaneProps {
@@ -149,6 +149,7 @@ export default function DrawingPane({ filePath, content, onContentChange, theme 
                 snapshot={snapshot}
                 onMount={handleMount}
                 components={CANVAS_COMPONENTS}
+                shapeUtils={CANVAS_SHAPE_UTILS}
                 colorScheme={theme === 'light' ? 'light' : 'dark'}
                 // Required once deployed, not cosmetic: on a non-localhost HTTPS
                 // origin, tldraw with no key reports `unlicensed-production` and

--- a/src/components/NotebookPane.tsx
+++ b/src/components/NotebookPane.tsx
@@ -10,7 +10,7 @@ import { parseNotebookFile, serializeNotebookFile, type NotebookUiState } from '
 import { isEmptyOverlay, type PageOverlay } from '../utils/pdfOverlay';
 import { svgToVectorOps } from '../utils/pdfVector';
 import { setNotebookRenderData } from '../utils/notebookRenderCache';
-import { CANVAS_COMPONENTS, applyCanvasUi, applyPenDefaults, readCanvasUi } from './canvasPen';
+import { CANVAS_COMPONENTS, CANVAS_SHAPE_UTILS, applyCanvasUi, applyPenDefaults, readCanvasUi } from './canvasPen';
 import { subscribePenScale } from '../utils/penStyle';
 
 interface NotebookPaneProps {
@@ -471,6 +471,7 @@ export default function NotebookPane({ filePath, content, onContentChange, onCon
                 assets={assetStore}
                 onMount={handleMount}
                 components={CANVAS_COMPONENTS}
+                shapeUtils={CANVAS_SHAPE_UTILS}
                 colorScheme={NOTEBOOK_COLOR_SCHEME}
                 licenseKey={import.meta.env.VITE_TLDRAW_LICENSE_KEY}
             />

--- a/src/components/PdfAnnotateCanvas.tsx
+++ b/src/components/PdfAnnotateCanvas.tsx
@@ -6,7 +6,7 @@ import { pageLayout, openPdfPages, PAGE_RENDER_SCALE, type PdfPageSize, type Pdf
 import { setPdfRenderData } from '../utils/pdfRenderCache';
 import { isEmptyOverlay, type PageOverlay } from '../utils/pdfOverlay';
 import { svgToVectorOps } from '../utils/pdfVector';
-import { CANVAS_COMPONENTS, applyCanvasUi, applyPenDefaults, readCanvasUi, type CanvasUiState } from './canvasPen';
+import { CANVAS_COMPONENTS, CANVAS_SHAPE_UTILS, applyCanvasUi, applyPenDefaults, readCanvasUi, type CanvasUiState } from './canvasPen';
 
 interface PdfAnnotateCanvasProps {
     filePath: string;
@@ -565,6 +565,7 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
                 assets={assetStore}
                 onMount={handleMount}
                 components={CANVAS_COMPONENTS}
+                shapeUtils={CANVAS_SHAPE_UTILS}
                 colorScheme={ANNOTATE_COLOR_SCHEME}
                 licenseKey={import.meta.env.VITE_TLDRAW_LICENSE_KEY}
             />

--- a/src/components/PenDevPanel.tsx
+++ b/src/components/PenDevPanel.tsx
@@ -1,0 +1,249 @@
+// A dev-only panel for feeling out the pen's streamline.
+//
+// It exists because the number it controls cannot be judged by reading: the
+// difference between tldraw's 0.64 and this app's 0.4 is invisible in a diff,
+// obvious on a tablet, and a rebuild between each try is slow enough that you
+// stop trusting the comparison. So: move the slider, draw, move it back, draw
+// again — two strokes at two settings sitting side by side on one canvas.
+//
+// Rendered through a PORTAL onto document.body rather than into tldraw's own
+// layout: `position: fixed` inside a transformed ancestor resolves against that
+// ancestor, and the canvas container is transformed.
+//
+// Its CSS lives HERE rather than in index.css so that the whole panel — markup,
+// logic and styles — leaves the production build together. Rules in the app
+// stylesheet would ship whether or not anything could ever match them.
+//
+// DEV ONLY. canvasPen.ts mounts it behind `import.meta.env.DEV`, which is a
+// build-time literal, so the reference dies and this module is dropped from the
+// production bundle entirely — verified by grepping dist for its markup.
+
+import { useCallback, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import { getStrokePoints } from 'tldraw';
+import {
+    PEN_STREAMLINE, TLDRAW_STREAMLINE, getPenStreamline, setPenStreamline, subscribePenStreamline,
+} from '../utils/penDev';
+
+/** Points-per-event a tablet actually produces, for the lag readout below. */
+const SPACING = 12;
+
+/**
+ * How far the ink would trail the pen at this setting, in px.
+ *
+ * Measured, not modelled: it runs tldraw's own `getStrokePoints` over a
+ * straight synthetic stroke and compares the smoothed centreline's last point
+ * to the raw one. Stroke width is deliberately absent — it does not affect
+ * tracking at all, and an earlier attempt to measure this from the rendered
+ * OUTLINE was wrong for exactly that reason.
+ */
+function lagAt(streamline: number): number {
+    const raw = [];
+    for (let i = 0; i < 60; i++) raw.push({ x: i * SPACING, y: 0, z: 0.5 });
+    const pts = getStrokePoints(raw, {
+        size: 3, thinning: 0, streamline, smoothing: 0.62, simulatePressure: false, easing: (t: number) => t,
+    });
+    const tip = pts[pts.length - 1].point;
+    return Math.hypot(tip.x - raw[raw.length - 1].x, tip.y - raw[raw.length - 1].y);
+}
+
+const PRESETS: Array<[string, number]> = [
+    ['tldraw stock', TLDRAW_STREAMLINE],
+    ['heavy', 0.4],
+    ['light', 0.1],
+    ['ships as', PEN_STREAMLINE],
+];
+
+const PANEL_CSS = `
+    /* Bottom-RIGHT, not left: the sidebar is user-resizable and can be
+       collapsed, so a left anchor lands on top of it at some widths. The right
+       edge is always canvas. Lifted clear of tldraw's dev watermark. */
+    .pen-dev {
+      position: fixed;
+      right: 16px;
+      bottom: 62px;
+      z-index: 9999;
+      width: 232px;
+      padding: 10px 12px 12px;
+      border-radius: 10px;
+      background: color-mix(in srgb, var(--background-primary) 92%, transparent);
+      border: 1px solid var(--background-modifier-border);
+      box-shadow: 0 6px 22px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(6px);
+      font-size: 12px;
+      color: var(--text-normal);
+    }
+
+    .pen-dev-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-weight: 600;
+    }
+
+    .pen-dev-head em {
+      font-style: normal;
+      margin-left: 4px;
+      padding: 1px 5px;
+      border-radius: 4px;
+      background: var(--interactive-accent);
+      color: #fff;
+      font-size: 9px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .pen-dev-head button {
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      cursor: pointer;
+      font-size: 15px;
+      line-height: 1;
+      padding: 0 2px;
+    }
+
+    .pen-dev-value {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin: 8px 0 2px;
+    }
+
+    .pen-dev-value strong {
+      font-size: 20px;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .pen-dev-value span {
+      color: var(--text-muted);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .pen-dev input[type='range'] {
+      width: 100%;
+      accent-color: var(--interactive-accent);
+    }
+
+    .pen-dev-presets {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 4px;
+      margin-top: 8px;
+    }
+
+    .pen-dev-presets button {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      padding: 5px 4px;
+      border-radius: 6px;
+      border: 1px solid var(--background-modifier-border);
+      background: var(--background-secondary);
+      color: var(--text-muted);
+      cursor: pointer;
+      font-size: 10px;
+    }
+
+    .pen-dev-presets button:hover {
+      color: var(--text-normal);
+    }
+
+    .pen-dev-presets button.is-on {
+      border-color: var(--interactive-accent);
+      color: var(--text-normal);
+    }
+
+    .pen-dev-presets em {
+      font-style: normal;
+      font-variant-numeric: tabular-nums;
+      font-size: 11px;
+      color: var(--text-normal);
+    }
+
+    .pen-dev p {
+      margin: 9px 0 0;
+      color: var(--text-muted);
+      font-size: 10.5px;
+      line-height: 1.45;
+    }
+
+    .pen-dev-tab {
+      position: fixed;
+      right: 16px;
+      bottom: 62px;
+      z-index: 9999;
+      padding: 5px 10px;
+      border-radius: 8px;
+      border: 1px solid var(--background-modifier-border);
+      background: color-mix(in srgb, var(--background-primary) 92%, transparent);
+      color: var(--text-muted);
+      cursor: pointer;
+      font-size: 11px;
+    }
+`;
+
+export default function PenDevPanel() {
+    const streamline = useSyncExternalStore(subscribePenStreamline, getPenStreamline);
+    const [open, setOpen] = useState(true);
+    const onSlide = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setPenStreamline(Number(e.target.value));
+    }, []);
+
+    // The collapsed tab carries the stylesheet too — it is its own portal, and
+    // the panel that would otherwise have injected the rules is not mounted.
+    if (!open) {
+        return createPortal(
+            <>
+                <style>{PANEL_CSS}</style>
+                <button className="pen-dev-tab" onClick={() => setOpen(true)} title="Pen tuning (dev only)">pen</button>
+            </>,
+            document.body,
+        );
+    }
+
+    return createPortal(
+        <div className="pen-dev">
+            <style>{PANEL_CSS}</style>
+            <div className="pen-dev-head">
+                <span>pen streamline <em>dev</em></span>
+                <button onClick={() => setOpen(false)} aria-label="Hide">×</button>
+            </div>
+
+            <div className="pen-dev-value">
+                <strong>{streamline.toFixed(2)}</strong>
+                <span>ink trails ~{lagAt(streamline).toFixed(1)}px</span>
+            </div>
+
+            <input
+                type="range"
+                min={0}
+                max={0.9}
+                step={0.01}
+                value={streamline}
+                onChange={onSlide}
+                aria-label="Streamline"
+            />
+
+            <div className="pen-dev-presets">
+                {PRESETS.map(([label, value]) => (
+                    <button
+                        key={label}
+                        className={Math.abs(value - streamline) < 0.005 ? 'is-on' : undefined}
+                        onClick={() => setPenStreamline(value)}
+                        title={`streamline ${value} — trails ~${lagAt(value).toFixed(1)}px`}
+                    >
+                        {label}<em>{value.toFixed(2)}</em>
+                    </button>
+                ))}
+            </div>
+
+            <p>
+                Applies to the <strong>next</strong> stroke — ink already drawn keeps its setting, so
+                you can lay strokes side by side. Higher smooths more and trails more: a graphics
+                tablet needs almost none, a trackpad or touchscreen more.
+            </p>
+        </div>,
+        document.body,
+    );
+}

--- a/src/components/canvasPen.ts
+++ b/src/components/canvasPen.ts
@@ -11,6 +11,8 @@ import type { Editor, TLShape } from 'tldraw';
 import { DefaultDashStyle, DefaultSizeStyle } from 'tldraw';
 import { getPenScale, seedPenScale } from '../utils/penStyle';
 import CanvasStylePanel from './CanvasStylePanel';
+import { TightDrawShapeUtil } from './tightDrawShape';
+import PenDevPanel from './PenDevPanel';
 
 /**
  * What a canvas file remembers about how you were drawing in it.
@@ -62,8 +64,23 @@ export function applyCanvasUi(editor: Editor, ui: CanvasUiState | undefined): vo
     }
 }
 
-/** What every canvas in the app passes to <Tldraw components={...}>. */
-export const CANVAS_COMPONENTS = { StylePanel: CanvasStylePanel };
+/**
+ * What every canvas in the app passes to <Tldraw components={...}>.
+ *
+ * The pen tuning panel rides along in development only. `import.meta.env.DEV`
+ * is a build-time literal, so in production the key is `undefined`, the import
+ * is unreferenced, and the panel is dropped from the bundle rather than shipped
+ * and hidden.
+ */
+export const CANVAS_COMPONENTS = {
+    StylePanel: CanvasStylePanel,
+    InFrontOfTheCanvas: import.meta.env.DEV ? PenDevPanel : undefined,
+};
+
+/** Ditto for <Tldraw shapeUtils={...}>. tldraw merges these over its own by
+ *  `type`, and this one is still `type: 'draw'`, so it substitutes rather than
+ *  adds — see tightDrawShape.tsx for what it changes and why. */
+export const CANVAS_SHAPE_UTILS = [TightDrawShapeUtil];
 
 /**
  * Make the pen behave the way the panel promises.
@@ -79,6 +96,13 @@ export const CANVAS_COMPONENTS = { StylePanel: CanvasStylePanel };
 export function applyPenDefaults(editor: Editor): () => void {
     // Only the width is ours to decide; a file that already stored a colour
     // keeps it, which is why this does not touch DefaultColorStyle.
+    //
+    // Dash stays 'solid': it is what keeps stroke width even, which is the whole
+    // point of the width slider. tldraw only consults `isPen` when dash is
+    // 'draw', so a stylus here never reaches realPressureSettings — but that
+    // branch buys only 0.74px of the 7.79px the ink trails (MEASURED on the
+    // smoothed centreline), and costs pressure-varying width. The trailing is
+    // `streamline`, and utils/tightDrawShape.tsx is where that is fixed.
     editor.run(() => {
         editor.setStyleForNextShapes(DefaultDashStyle, 'solid');
         editor.setStyleForNextShapes(DefaultSizeStyle, 's');

--- a/src/components/tightDrawShape.tsx
+++ b/src/components/tightDrawShape.tsx
@@ -1,0 +1,154 @@
+// Ink that keeps up with the nib.
+//
+// WHY THIS EXISTS AT ALL. tldraw chooses its freehand settings inside
+// `getFreehandOptions`, a module-private function in lib/shapes/draw/getPath.js
+// that DrawShapeUtil calls from its own methods. It is not a method, not
+// exported, and takes nothing from the editor — so there is no hook, and
+// re-rendering the shape ourselves is the only way to change the one number
+// that decides how far ink trails the pen.
+//
+// WHAT IT CHANGES: `streamline`, and nothing else. perfect-freehand places each
+// incoming point a fraction (1 - streamline) of the way toward where the pen
+// actually is, so it alone sets the lag. MEASURED on the smoothed CENTRELINE
+// (tldraw's own `getStrokePoints`, 12px between input points), with stroke
+// width proved irrelevant — identical lag at 3, 4.6, 6 and 10px:
+//
+//     0.64  tldraw's, for dash 'solid'          7.79px behind the pen
+//     0.62  tldraw's, for a stylus on 'draw'    7.05px
+//     0.40                                      2.10px
+//     0.01  ours                                0.00px
+//
+// SETTLED BY DRAWING, NOT BY ARGUING. The prediction from the arithmetic was
+// that somewhere near 0.35-0.45 would be the floor, because streamline is also
+// what hides a tablet's jitter and its polling grid. On an actual graphics
+// tablet that turned out to be wrong: the device reports finely enough that
+// there is no jitter left to hide, and effectively switching smoothing off
+// reads as the pen simply working. components/PenDevPanel.tsx is the panel
+// that made the comparison possible, and is the thing to reach for before
+// changing this number — it cannot be judged from a diff.
+//
+// A device that reports more coarsely (a trackpad, a touchscreen, a cheap
+// stylus) would want this back up. It is one constant, not a redesign.
+//
+// HOW LITTLE IT OWNS. Every method here delegates to tldraw unless the shape is
+// the one this app actually produces — `dash: 'solid'`, which canvasPen pins.
+// Dashed, dotted and 'draw' strokes keep tldraw's exact behaviour, so what we
+// maintain across upgrades is one branch, not a renderer.
+
+import {
+    Circle2d, DrawShapeUtil, Polygon2d, Polyline2d, SVGContainer, getDisplayValues,
+    getPointsFromDrawSegments, getStrokePoints, getSvgPathFromStrokePoints,
+    type StrokeOptions, type TLDrawShape,
+} from 'tldraw';
+import { getPenStreamline } from '../utils/penDev';
+
+/** tldraw's own value, kept so only the trailing changes and not the shape of
+ *  the curve between points. */
+const SMOOTHING = 0.62;
+
+function inkOptions(strokeWidth: number, complete: boolean): StrokeOptions {
+    return {
+        size: strokeWidth,
+        // Even width, whatever the pressure — this is what the width slider
+        // promises, and it is why dash stays 'solid' in canvasPen.ts.
+        thinning: 0,
+        streamline: getPenStreamline(),
+        smoothing: SMOOTHING,
+        simulatePressure: false,
+        easing: (t: number) => t,
+        last: complete,
+    };
+}
+
+/** `dash: 'solid'` is the only shape this app draws, and the only one we take
+ *  over; anything else is tldraw's to render. */
+const isOurs = (shape: TLDrawShape) => shape.props.dash === 'solid';
+
+/** Stroke width in the same terms DrawShapeUtil uses. */
+function widthOf(util: TightDrawShapeUtil, shape: TLDrawShape): number {
+    return (getDisplayValues(util, shape).strokeWidth + 1) * shape.props.scale;
+}
+
+/** A stroke is "complete" once it ends — freehand tapers the final cap then. */
+const isComplete = (shape: TLDrawShape) =>
+    shape.props.isComplete || shape.props.segments.at(-1)?.type === 'straight';
+
+/** tldraw's dot path, for a stroke too short to have a direction. */
+const dotPath = (p: { x: number; y: number }, sw: number) => {
+    const r = (sw + 1) * 0.5;
+    return `M ${p.x} ${p.y} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${r * 2},0`;
+};
+
+function pathFor(util: TightDrawShapeUtil, shape: TLDrawShape): { d: string; isDot: boolean } {
+    const points = getPointsFromDrawSegments(shape.props.segments, shape.props.scaleX, shape.props.scaleY);
+    const sw = widthOf(util, shape);
+    const strokePoints = getStrokePoints(points, inkOptions(sw, isComplete(shape)));
+    if (strokePoints.length < 2) return { d: dotPath(points[0], 0), isDot: true };
+    // A closed stroke is only filled as a region when it asks to be; an open
+    // one is a centreline that the <path> below strokes.
+    return { d: getSvgPathFromStrokePoints(strokePoints, shape.props.isClosed && shape.props.fill !== 'none'), isDot: false };
+}
+
+export class TightDrawShapeUtil extends DrawShapeUtil {
+    override component(shape: TLDrawShape) {
+        if (!isOurs(shape)) return super.component(shape);
+        const dv = getDisplayValues(this, shape);
+        const { d, isDot } = pathFor(this, shape);
+        // Solid ink is a stroked CENTRELINE, not an outline — the same thing
+        // tldraw renders for this dash, which is why this stays short.
+        return (
+            <SVGContainer>
+                <path
+                    d={d}
+                    strokeLinecap="round"
+                    fill={isDot ? dv.strokeColor : 'none'}
+                    stroke={dv.strokeColor}
+                    strokeWidth={widthOf(this, shape)}
+                />
+            </SVGContainer>
+        );
+    }
+
+    /** Bounds and hit-testing follow the ink. Left to tldraw this would still
+     *  be built at streamline 0.62/0.64, so a stroke's clickable path would sit
+     *  ~5px from the stroke you can see. */
+    override getGeometry(shape: TLDrawShape) {
+        if (!isOurs(shape)) return super.getGeometry(shape);
+        const points = getPointsFromDrawSegments(shape.props.segments, shape.props.scaleX, shape.props.scaleY);
+        const sw = widthOf(this, shape);
+        const strokePoints = getStrokePoints(points, inkOptions(sw, shape.props.isPen)).map(p => p.point);
+        if (strokePoints.length === 1) return new Circle2d({ x: -sw, y: -sw, radius: sw, isFilled: true });
+        if (shape.props.isClosed && strokePoints.length > 2) {
+            return new Polygon2d({ points: strokePoints, isFilled: shape.props.fill !== 'none' });
+        }
+        return new Polyline2d({ points: strokePoints });
+    }
+
+    /** The selection outline, which must trace the ink rather than hover beside it. */
+    override getIndicatorPath(shape: TLDrawShape) {
+        if (!isOurs(shape)) return super.getIndicatorPath(shape);
+        return new Path2D(pathFor(this, shape).d);
+    }
+
+    /** Export — the notebook's PDF and every SVG export come through here, and
+     *  a stroke that exported at tldraw's smoothing would not match the one on
+     *  screen. Filled/closed strokes are rare and stay tldraw's. */
+    override toSvg(shape: TLDrawShape, ctx: Parameters<DrawShapeUtil['toSvg']>[1]) {
+        if (!isOurs(shape) || (shape.props.isClosed && shape.props.fill !== 'none')) {
+            return super.toSvg(shape, ctx);
+        }
+        const dv = getDisplayValues(this, shape, ctx.colorMode);
+        const { d, isDot } = pathFor(this, shape);
+        return (
+            <g transform={`scale(${1 / shape.props.scale})`}>
+                <path
+                    d={d}
+                    strokeLinecap="round"
+                    fill={isDot ? dv.strokeColor : 'none'}
+                    stroke={dv.strokeColor}
+                    strokeWidth={widthOf(this, shape)}
+                />
+            </g>
+        );
+    }
+}

--- a/src/utils/penDev.ts
+++ b/src/utils/penDev.ts
@@ -1,0 +1,48 @@
+// The pen's streamline, as a store, so a dev panel can move it while you draw.
+//
+// A store rather than a constant because the whole point of the number is that
+// it has to be FELT: 0.64 and 0.4 are indistinguishable on paper and obvious on
+// a tablet. Shipping is still a constant — PEN_STREAMLINE is what production
+// uses, and the panel that writes this is dev-only (see components/PenDevPanel).
+//
+// Changing it affects the NEXT stroke; ink already on the canvas keeps the
+// value it was drawn with, which is what lets one canvas hold a row of strokes
+// at different settings for comparison.
+
+/**
+ * What the pen ships with.
+ *
+ * Effectively no smoothing: ink goes where the pen went. Chosen by drawing with
+ * it rather than by reasoning about it — the panel this store exists for was
+ * built precisely because the difference between 0.64, 0.4 and 0.01 is
+ * invisible in a diff and unmistakable on a tablet, and a graphics tablet
+ * reports finely enough that there is no jitter left for smoothing to hide.
+ *
+ * See components/tightDrawShape.tsx for what the number does and what it cost
+ * to reach it.
+ */
+export const PEN_STREAMLINE = 0.01;
+
+/** tldraw's own value for a solid stroke, kept here as the thing to compare
+ *  against — the panel offers it as a preset so "is this better than stock"
+ *  is one click rather than a rebuild. */
+export const TLDRAW_STREAMLINE = 0.64;
+
+let current = PEN_STREAMLINE;
+const listeners = new Set<() => void>();
+
+export function getPenStreamline(): number {
+    return current;
+}
+
+export function setPenStreamline(value: number): void {
+    const next = Math.min(0.95, Math.max(0, value));
+    if (next === current) return;
+    current = next;
+    for (const listener of listeners) listener();
+}
+
+export function subscribePenStreamline(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => { listeners.delete(listener); };
+}


### PR DESCRIPTION
Drawing felt worse here than [tldraw's own demo](https://www.tldraw.com/), and the cause was a line I added in the pen-panel work: `canvasPen.ts` pins `dash: 'solid'`, and tldraw picks its freehand settings like this:

```js
if (shapeProps.dash === "draw") {
  if (shapeProps.isPen) return realPressureSettings(...)
  else                  return simulatePressureSettings(...)
}
return solidSettings(...)   // isPen is never consulted
```

A stylus was being correctly detected as `isPen: true` and then discarded, landing every stroke on `streamline: 0.64`.

## The fix I tried first was wrong, and worth recording

Un-pinning the dash looked like it halved the lag. It didn't — I was measuring the distance from the pen to the rendered **outline's** leading edge, and `realPressureSettings` sizes ink as `1 + sw*1.2` instead of `sw`. A fatter stroke reaches nearer the nib while tracking no better. The giveaway was in my own numbers: trailing fell as stroke **size** rose, which streamline cannot explain.

Measured properly — on the centreline, via tldraw's `getStrokePoints`, with width proved irrelevant (identical lag at 3, 4.6, 6 and 10 px) — `dash: 'draw'` was worth **0.74 px of 7.79 px**. Nine percent, in exchange for pressure-varying width that the pen-width slider exists to avoid. Reverted.

## What actually fixes it

`streamline`, which tldraw does not expose: `getFreehandOptions` is module-private in `lib/shapes/draw/getPath.js`, called from `DrawShapeUtil`'s own methods, and takes nothing from the editor. No hook exists, so the draw shape is forked — narrowly.

`tightDrawShape.tsx` overrides four methods, each delegating to `super` unless `dash === 'solid'`, the only stroke this app makes:

| method | why it's here |
|---|---|
| `component` | the ink itself |
| `getGeometry` | or clicking a stroke misses it by ~5 px |
| `getIndicatorPath` | or the selection outline floats beside the ink |
| `toSvg` | or the notebook's PDF export uses tldraw's smoothing and quietly stops matching the screen |

Dashed, dotted and `draw` strokes keep tldraw's exact code path. What we own across upgrades is one branch, not a renderer.

| streamline | ink behind the pen |
|---|---|
| 0.64 (tldraw's) | 7.79 px |
| 0.40 | 2.10 px |
| **0.01 (ours)** | **0.00 px** |

## The number was settled by drawing, not by arguing

The arithmetic predicted 0.35–0.45 would be the practical floor, since streamline is also what hides a tablet's jitter. On a real graphics tablet that was wrong — it reports finely enough that there's nothing left to hide, and effectively switching smoothing off reads as the pen simply working.

`PenDevPanel.tsx` is the dev-only panel built to make that comparison possible: slider plus presets, applying to the **next** stroke so one canvas can hold strokes at several settings side by side. Gated on `import.meta.env.DEV`, portalled to `<body>` (a `position: fixed` panel inside the camera-transformed canvas container resolves against the wrong box), and it carries its own CSS in a `<style>` tag rather than `index.css` so that markup, logic **and** styles all leave the production build together — verified by grepping `dist` for each.

## Notes

- Streamline is applied at **render** time and nothing about it is stored, so existing drawings re-render at the new value. No stroke data changes.
- A device that reports more coarsely — trackpad, touchscreen, cheap stylus — would want this back up. It's one constant.
- Ruled out along the way, for the record: the app is **not** slower than tldraw.com. 60 fps and 0 ms blocked main thread during a stroke on a 2,234-row vault, in notebooks, with ink already on the page, and an 83%-idle CPU profile. Identical 7.7 px when tldraw.com is forced into our config.

## Verification

`typecheck`, `lint`, `build` clean. E2E: `pen`, `penmemory`, `notebook`, `pages` and the in-place PDF annotation test all pass. Notebook PDF export still builds (1984 vs 1980 bytes — expected, the stroke path genuinely changed and the export now matches the screen).