### PR TITLE
Bring every tab back when a link or a reload opens a vault

### DIFF
--- a/.agents/skills/tabs-and-panes/SKILL.md
+++ b/.agents/skills/tabs-and-panes/SKILL.md
@@ -60,12 +60,29 @@ runs **once per vault**, on a cold start and again on every switch back to it.
   at and then narrowed by the positions that actually came back, so a note deleted on disk since
   takes its share with it and the rest divide it up — exactly as closing that pane would have.
 - **The whole stored session is read synchronously, before the restore pass yields to its file
-  reads** — persistence is un-gated the moment the pass claims its refs, so a value read after the
-  awaits could already have been rewritten by it, and a split would come back silently flattened.
+  reads** — the claim is what un-gates persistence, so a value read after the awaits could already
+  have been rewritten, and a split would come back silently flattened. `restoringRef` (below) now
+  also shuts persistence for the reads, but one snapshot makes that unreachable, not merely unreached.
 - `restoreLayout` gives any path a stored group can't account for a tab of its own; a session written
   before split tabs restores as all-singletons. A path whose file is gone is simply skipped.
 - **An empty `paths` is a real session** — "I closed everything in this vault" — and must survive a
   switch. Nothing may treat it as absence on the way *in*.
+- **The restore pass is the ONLY thing that opens documents when a vault loads.** The address bar's
+  note (`initialLocation`, captured once) is folded INTO it: consumed by the first vault the page
+  restores, applied only when `findLinkedVault` — the resolver FileSystemContext picked the vault
+  with — resolves the link to `currentVaultId`, read alongside the saved paths (one they lack becomes
+  a trailing singleton through `restoreLayout`) and focused as its `wantActive`. 5de752e opened it
+  with a second, racing `handleFileClick` instead; the pass saw that tab after its reads and bailed
+  *after the claim*, so the persist effect filed the one tab as the vault's whole session. Measured:
+  four documents in three tabs (one a 65/35 split) reloaded as one tab, the stored `paths` rewritten
+  from four to that one. Persistence is live from the claim, so **an early return after it, with tabs
+  on screen, leaves the next commit to file those tabs as the vault's whole session** — which is why
+  what is opened while the reads are in flight (a tree click) is **merged** (`mergeLayouts`: the saved
+  tabs first, as left, then what was opened, keeping its focus and its in-memory `OpenTab`), never
+  deferred to, and why the reads themselves are the one stretch where **nothing is persisted at all**
+  (`restoringRef`, a per-pass token released just before the merge is dispatched, and in `finally`).
+  Without that gate a click 100ms into a 600ms-per-file restore held the stored session at that one
+  tab for 2.4s, and a reload inside the window lost the rest for good.
 - Everything read back is shape-guarded (`isStoredSession`); localStorage is user-editable and holds
   whatever an older build wrote, and a malformed entry reads as `null`.
 - Restored PDF tabs get `content: ''` exactly like `handleFileClick` (their buffer is a tldraw
@@ -123,9 +140,25 @@ mount path and `restoreVault` call `recordVault` FIRST and walk after, which is 
 reload and the permission button looked fine. Above the claim, the pass simply waits for the id;
 nothing is left un-gated, because the persist effect's own first line is the same check.
 
-The pass still re-checks the vault after its file reads, alongside the "did the user open something
-already" guard: the switch empties the tab set, so that guard alone waves the old vault's tabs
-straight through.
+The pass re-checks the vault (handle AND id, via `rootHandleRef`/`currentVaultIdRef`) after its file
+reads and **before** the merge, and that check alone keeps a mid-restore switch's OLD tabs out of the
+new vault: the switch empties the tab set, so the merge would lay them straight over it. Asset
+baselines are seeded only after it, for the same reason — the switch has just cleared that map.
+`restoringRef` is reset at **every claim**, so a pass still reading the vault just left cannot hold
+the incoming vault's gate. A pass whose reads ALL fail still dispatches a merge when `layoutRef` says
+something was opened meanwhile, because the gate held that commit's own write back; and when
+`layoutRef` has not caught up yet the pass returns instead, leaving the flush that updates it to run
+the persist effect immediately after the `finally` — that ref's effect is declared above it. One
+write either way, which is what makes the stale ref harmless rather than merely unlikely.
+
+**What the gate costs, and why it is still the right trade.** A note opened during the reads and then
+abandoned by a vault SWITCH inside the same window is never filed under the outgoing vault: its write
+was gated, and the pass then returns at the vault re-check without dispatching a merge (measured — a
+tree click 150ms into a 2.4s restore, switching away at 400ms, left the stored session at its
+original four paths). Only the memory that a tab was open is lost, never a file, and the alternative
+is writing a session from the gated path — which is exactly the hazard the gate exists for. A read
+that never settles is the same trade taken to its limit: nothing in that vault is persisted until
+some other vault's claim resets the token (see above), which is the safe direction to fail.
 
 # Split tabs (`utils/tabGroups.ts`, `DocumentPane.tsx`, `EditorPane.tsx`)
 

--- a/.agents/skills/verify-in-browser/SKILL.md
+++ b/.agents/skills/verify-in-browser/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: verify-in-browser
-description: How to actually verify a change in this repo — there is no test suite, so verification means driving the running app headlessly with Playwright against an OPFS-stubbed vault. Load before writing any verification script, before driving the app, and before claiming a change works.
+description: How to actually verify a change in this repo — there is no test suite, so verification means Playwright driving the running app in headless Chromium against an OPFS-stubbed vault. Load before writing any verification script, before driving the app, and before claiming a change works.
 ---
 
 # Verifying a change
 
 **There is no test suite and no test runner.** `npm run typecheck` and `npm run lint` are the
-static gates; everything behavioural is verified by driving the running app. A change is not
-verified because it typechecks.
+static gates; everything behavioural is verified by Playwright driving the running app in headless
+Chromium. A change is not verified because it typechecks.
+
+**Playwright is not a repo dependency.** Nothing in `package.json` pulls it and there is no
+`node_modules/playwright`; it resolves out of the npx cache
+(`~/.npm/_npx/*/node_modules/playwright`), and the harness hard-filters that cache on **1.63**.
+`channel: 'chrome'` (step 7) additionally needs Google Chrome installed, or the launch fails outright.
 
 ## The harness, step by step
 
@@ -30,27 +35,52 @@ Each step below exists because skipping it produces a *working change that looks
 5. **Press `⌘E` before testing anything about the caret, typing, or cell editing.** Files open in
    Reading mode by default, where nothing is editable.
 
-6. **Selectors:** the editor is `.cm-content` inside `.cm-scroller`. Chromium only, by design. On the
-   welcome screen the only control is a button reading **Open Vault**; `aria-label="Open another
-   vault"` exists only once a vault is already open, and `.vault-menu-row` only inside that menu.
+6. **Selectors:** the editor is `.cm-content` inside `.cm-scroller`. Chromium only, by design. The
+   welcome screen carries up to **two** `.welcome-btn`s, and the second one opens a *different*
+   vault: `Open Vault` (always — the picker) plus either `Open '<linked vault>'` (a hash naming a
+   known vault whose grant has lapsed) or `Restore '<previous vault>'` (a stored handle whose grant
+   has lapsed). Never both — the linked branch returns before the stored one is reached. Match
+   `{ name: 'Open Vault', exact: true }`; a loose `{ name: 'Open' }` is ambiguous on the linked
+   screen. `aria-label="Open another vault"` exists only once a vault is already open, and
+   `.vault-menu-row` only inside that menu.
 
-7. **A reload with a vault open CRASHES headless Chromium** (both `chromium` and
-   `chrome-headless-shell`, Playwright 1.63): reading the OPFS handle back out of IndexedDB kills the
-   renderer *and* the browser with no crash log. It is an OPFS limitation, not an app bug — but it
-   means the stock recipe cannot test reload, restore-on-load, or anything with two vaults. The
-   trigger is narrower than "a reload": it is any READ of a stored handle, so the **second** vault
-   you open dies inside `rememberVault`'s `isSameEntry` sweep over the list (the first is fine —
-   `readList` returns `[]`, so nothing is deserialized). Work around it by `page.route`-intercepting
-   the `idb-keyval` module with a localStorage shim that stores `{__handle: name}` and re-resolves it
-   from the OPFS root — **pack/unpack recursively**, because `recent-vaults` is an array of objects
-   each holding a handle, not a bare handle — or by deleting the `keyval-store` database before the
-   reload and re-opening through the picker. Say which you did: the shim means the real
-   structured-clone path went unexercised.
+7. **A reload with a vault open CRASHES Playwright's BUNDLED Chromium** (both `chromium` and
+   `chrome-headless-shell`, 153.0.8010.12 under Playwright 1.63): reading the OPFS handle back out of
+   IndexedDB kills the renderer *and* the browser with no crash log. The trigger is narrower than
+   "a reload": it is any READ of a stored handle, so the **second** vault you open dies inside
+   `rememberVault`'s `isSameEntry` sweep over the list (the first is fine — `readList` returns `[]`,
+   so nothing is deserialized). It tracks the **browser build**, not headedness and not the app:
+   on identical app code the *installed Chrome* channel survives it, headless.
+
+   So, two ways to test reload / restore-on-load / two vaults — say which you took:
+   - **`chromium.launch({ headless: true, channel: 'chrome' })`, no shim.** Still headless, but the
+     installed Google Chrome instead of the bundled build, so the real structured-clone path is the
+     one under test (`indexedDB.databases()` → `keyval-store`, no `__h_idb:` keys). Measured: Chrome
+     151.0.7922.138 survived **14 of 14** reloads that deserialize the stored handle, across 4
+     sessions (dev server and `vite preview`), plus both second-vault opens — while the bundled 153
+     died on the first such reload in both controls. Prefer this. It is not permanent, though: the
+     surviving build is whichever Chrome is installed, and the crashing one is the *newer* of the
+     two, so a Chrome update can inherit the bug — if this arm starts dying too, fall back to the
+     shim rather than reading it as an app regression.
+   - **`page.route`-intercept the `idb-keyval` module** with a localStorage shim storing
+     `{__handle: name}`, re-resolved from the OPFS root — **pack/unpack recursively**, because
+     `recent-vaults` is an array of objects each holding a handle, not a bare handle. Works on the
+     bundled build, but the real structured-clone path then goes unexercised. (Deleting the
+     `keyval-store` database before the reload and re-opening through the picker dodges the read
+     instead — and dodges what you were testing, if that was the restore.)
+
+   **A `goto` that differs only in the `#hash` does not reload** — it navigates in-page, the restore
+   effect never re-runs, and a link-opens-a-note probe silently proves nothing. Force it
+   (`page.reload()`), and assert you did: set a `window` marker before, check it is gone after.
 
 8. **`await document.fonts.ready` before asserting a column width.** Two fonts re-trigger the table
-   fit when they land, and only one of them is a request you could watch for: Google Fonts is the
-   app's one outbound request, but **KaTeX's faces are bundled locally** and a table holding maths
-   re-fits when they arrive too (`tableFit`'s `mathProbe`). Offline is not an exemption.
+   fit when they land, and only one of them is a request you could watch for. The app reaches **two**
+   Google hosts: `index.html` links a `fonts.googleapis.com` stylesheet (Fira Code) and preconnects
+   `fonts.gstatic.com`, and a chosen text font adds a second stylesheet at runtime (`App.tsx`'s
+   `google-font-link`) — but the request that moves layout is the **gstatic woff2**, fetched only for
+   a face something actually renders, so a default load makes no font request at all. **KaTeX's faces
+   are bundled locally** and a table holding maths re-fits when they arrive too (`tableFit`'s
+   `mathProbe`). Offline is not an exemption.
 
 9. **Suppressed browser menus are asserted, not screenshotted.** To check the app's own context menu
    replaced the browser's, assert `defaultPrevented` on the `contextmenu` event — the OS menu never

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,8 @@ npm run preview    # serve a production build
 ```
 
 **There is no test suite and no test runner.** `typecheck` and `lint` are the only static gates;
-everything behavioural is verified by driving the app headlessly — see the `verify-in-browser` skill,
-and use it before saying a change works.
+everything behavioural is verified by Playwright driving the app in headless Chromium — see the
+`verify-in-browser` skill, and use it before saying a change works.
 
 **Env:** `VITE_TLDRAW_LICENSE_KEY` — production only; a missing key never shows up in `npm run dev`.
 
@@ -76,8 +76,8 @@ and use it before saying a change works.
 - **Paths are vault-root-relative with no vault-name prefix**, centralized in `utils/paths.ts`;
   `buildFileTree` and every create/move/rename tab handler must agree or tabs stop deduping.
 - **The URL hash mirrors `{vault, file}`** (`utils/appUrl.ts`), NAMING a stored vault: the FS Access
-  API takes no path. On load it outranks the stored handle, a lapsed grant becomes a one-button
-  screen (`requestPermission` needs a gesture), and it is read ONCE — a writer effect then owns it.
+  API takes no path. Read ONCE on load (a writer effect then owns it), it outranks the stored handle;
+  its `file` is opened only BY the session restore, in the vault it names — never by a second opener.
 - **Open documents are a flat list (`tabs`) plus a separate tab *layout*;** `activeTabPath` is
   derived. The save funnel `updateTabContent(path, content)` is **path-explicit and the only one** —
   several documents are editable at once and canvas panes serialize after their pane has gone. The

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
   focusedPath as focusedPathOf,
   groupById,
   mergeIntoActive,
+  mergeLayouts,
   openTab as openTabIn,
   renamePath,
   reorderGroups,
@@ -33,7 +34,7 @@ import {
 import { clampTabSize } from './editor/lists';
 import { retryMissingAssets } from './editor/imageWidget';
 import { getNotebookExporter, clearNotebookRenderData, moveNotebookRenderData } from './utils/notebookRenderCache';
-import { readLocation, vaultLinkName, writeLocation } from './utils/appUrl';
+import { findLinkedVault, readLocation, vaultLinkName, writeLocation } from './utils/appUrl';
 import {
   ENTRY_STYLE_FILE, LEGACY_STYLE_FILE, emptyEntryStyles, forgetEntry, parseEntryStyles,
   renameEntry, serializeEntryStyles, withEntryStyle, type IconNode,
@@ -554,6 +555,18 @@ export default function App() {
    */
   const sessionRootRef = useRef<FileSystemDirectoryHandle | null>(null);
   const sessionVaultIdRef = useRef<string | null | undefined>(undefined);
+  /**
+   * The restore pass still READING the claimed vault's files, if one is — and
+   * while it is, nothing is persisted. Claiming the two refs above is what
+   * un-gates persistence, and the claim comes before the reads, so a note opened
+   * in that window was written out as the vault's whole session until the merge
+   * wrote it back (measured: a tree click 100ms into a restore reading 600ms per
+   * file held the stored session at that one tab for 2.4s, and a reload inside
+   * the window came back with only it — all four saved documents, split and
+   * all, gone for good). A token rather than a flag, so a pass that outlives a
+   * switch cannot release the gate a later pass holds.
+   */
+  const restoringRef = useRef<object | null>(null);
 
   // The open vault, for the async restore pass to re-check after its awaits —
   // BOTH halves of it, because `currentVaultId` lags `rootHandle` by a commit on
@@ -607,6 +620,7 @@ export default function App() {
     if (!currentVaultId) return;                              // no id → nowhere to file it
     if (sessionRootRef.current !== rootHandle) return;        // the workspace is still the old vault's
     if (sessionVaultIdRef.current !== currentVaultId) return; // …or this vault's restore has not run yet
+    if (restoringRef.current) return;                         // …or is still reading (see restoringRef)
     writeSession(currentVaultId, {
       paths: layout.groups.flatMap(g => g.paths),
       groups: layout.groups.map(g => g.paths),
@@ -1350,8 +1364,24 @@ export default function App() {
     []
   );
 
+  /**
+   * The address bar AS THE PAGE LOADED, captured once.
+   *
+   * Not re-read later: the URL writer further down rewrites the hash as the
+   * app settles, and one render where a vault is open but the labelled list has
+   * not caught up used to clear it — wiping the link before its note had been
+   * opened. Reading a link that is being kept up to date is the mistake; the
+   * instruction is what arrived, once. Declared here because its one reader is
+   * the restore pass below.
+   */
+  const [initialLocation] = useState(readLocation);
+  /** Consumed by the first vault this page restores (see the restore pass). */
+  const linkPendingRef = useRef(true);
+
   // Auto-restore THIS VAULT'S tabs once its file tree has loaded — on a cold
-  // start and on every switch back to it.
+  // start and on every switch back to it. The ONLY thing that opens documents
+  // when a vault loads: the note a link names is folded in rather than opened
+  // beside it, which raced this pass and cost the vault its tabs (see below).
   useEffect(() => {
     // Nothing to restore against yet — and NOTE that this return is above the
     // claim below, so a vault can set `currentVaultId` and never claim (an
@@ -1391,67 +1421,147 @@ export default function App() {
     // top is the one that precedes it, deliberately: see there.)
     sessionRootRef.current = rootHandle;
     sessionVaultIdRef.current = currentVaultId;
+    // Every claim starts with persistence open: a pass still reading an earlier
+    // vault's files must not hold this one's gate — a vault with nothing to
+    // read would otherwise persist nothing until that pass finished.
+    restoringRef.current = null;
+    const vaultFiles = collectFiles(fileTree);
+
+    // The note the address bar names, when it belongs HERE. Consumed at the
+    // claim, so it applies to the first vault this page restores and never
+    // again on a later switch back to it. Resolved through the same
+    // findLinkedVault FileSystemContext picked the vault with, so the two
+    // agree: an unknown name that fell back to the last-used vault, another
+    // vault chosen from the "Open 'X'" screen, or a hash naming no vault at all
+    // opens that vault as it was left — the old opener instead opened the
+    // link's path out of whichever vault loaded, if a file happened to sit
+    // there. (The one blur: two known vaults sharing the link's name, with no
+    // id suffix to part them — the link names both, and which it resolves to
+    // here follows the list's order at this claim.) Text and PDF only,
+    // handleFileClick's own test for "opens as a tab": anything else would be
+    // a window.open on page load.
+    const link = linkPendingRef.current ? initialLocation : null;
+    linkPendingRef.current = false;
+    const linkedNode = link?.file && findLinkedVault(link.vault, recentVaults)?.id === currentVaultId
+      ? vaultFiles.find(f => f.path === link.file && (isTextFile(f.name) || isPdfFile(f.name)))
+      : undefined;
 
     // Read the session WHOLE and synchronously, before the file reads below
-    // yield: persistence is un-gated the moment the refs are claimed, so
-    // anything that fires it while the reads are in flight would have rewritten
-    // the entry — and the split would come back silently flattened. Deciding
-    // the whole restore from one snapshot is what makes that unreachable rather
-    // than merely unreached.
+    // yield: the refs just claimed are what the persist effect checks, so a
+    // value read after the awaits could already have been rewritten — and the
+    // split would come back silently flattened. restoringRef now also shuts
+    // persistence for the reads, but deciding the whole restore from one
+    // snapshot is what makes that unreachable rather than merely unreached.
     const stored = readSession(currentVaultId);
-    // An empty `paths` is a real session ("I closed everything here"); there is
-    // simply nothing to open for it.
-    if (!stored || stored.paths.length === 0) return;
+    // A linked note the session does not hold joins it at the end, like any
+    // newly opened note — restoreLayout gives a path no stored group accounts
+    // for a tab of its own. An empty `paths` is a real session ("I closed
+    // everything here"); there is simply nothing of its own to open for it. A
+    // Set, because a path listed twice (a hand-edited record) would mint two
+    // tabs for one document — restoreLayout dedupes the layout, not the tabs.
+    const paths = stored ? [...new Set(stored.paths)] : [];
+    if (linkedNode && !paths.includes(linkedNode.path)) paths.push(linkedNode.path);
+    if (paths.length === 0) return;
 
+    // Persistence stays shut from here until the merge is dispatched — see
+    // restoringRef. Released in `finally` too, so no exit leaves it shut.
+    const token = {};
+    restoringRef.current = token;
+    const release = () => { if (restoringRef.current === token) restoringRef.current = null; };
     (async () => {
-      const vaultFiles = collectFiles(fileTree);
-      const restored: OpenTab[] = [];
-      for (const path of stored.paths) {
-        if (path === 'help-guide') {
-          restored.push({ id: newTabId(), file: { name: 'Help Guide', isHelp: true, path }, content: HELP_DOC_CONTENT, mode: 'read', dirty: false });
-          continue;
+      try {
+        const restored: OpenTab[] = [];
+        for (const path of paths) {
+          if (path === 'help-guide') {
+            restored.push({ id: newTabId(), file: { name: 'Help Guide', isHelp: true, path }, content: HELP_DOC_CONTENT, mode: 'read', dirty: false });
+            continue;
+          }
+          const node = vaultFiles.find(f => f.path === path);
+          if (!node) continue; // file deleted/moved externally — skip it
+          try {
+            // Mirror handleFileClick: a PDF's buffer holds its tldraw snapshot
+            // (PdfPane reads the bytes itself) — decoding a PDF as UTF-8 would
+            // fill the buffer with garbage.
+            const content = isPdfFile(node.name) ? '' : await readFile(node.handle as FileSystemFileHandle);
+            restored.push({ id: newTabId(), file: node, content, mode: 'read', dirty: false });
+          } catch (err) {
+            console.error('Failed to restore tab:', path, err);
+          }
         }
-        const node = vaultFiles.find(f => f.path === path);
-        if (!node) continue; // file deleted/moved externally — skip it
-        try {
-          // Mirror handleFileClick: a PDF's buffer holds its tldraw snapshot
-          // (PdfPane reads the bytes itself) — decoding a PDF as UTF-8 would
-          // fill the buffer with garbage.
-          const content = isPdfFile(node.name) ? '' : await readFile(node.handle as FileSystemFileHandle);
-          rememberAssetRefs(node, content);   // see handleFileClick
-          restored.push({ id: newTabId(), file: node, content, mode: 'read', dirty: false });
-        } catch (err) {
-          console.error('Failed to restore tab:', path, err);
+        // Nothing of the session came back (every note in it deleted since, or
+        // unreadable) and nothing was opened meanwhile: the stored session is
+        // left as it was. Something that WAS opened still goes through the
+        // merge, with nothing to lay it over — the gate held its write back, and
+        // the merge's new layout is the only thing that will write it now.
+        if (restored.length === 0 && layoutRef.current.groups.length === 0) return;
+        // The reads above yield to the event loop: the vault may have been
+        // switched in the meantime, and the switch effect empties the tab set,
+        // so the merge below would drop the OLD vault's notes (handles and all)
+        // into the new vault's workspace. The HANDLE is checked as well as the
+        // id, and it is the half that catches it: `currentVaultId` lags
+        // `rootHandle` by a commit, so a switch whose reads land in that window
+        // passes an id test comparing the outgoing id with itself (measured:
+        // with a 600ms-per-file read, switching away mid-restore put vault A's
+        // three tabs on screen over vault B's tree, autosaving through A's
+        // handles).
+        if (rootHandleRef.current !== rootHandle) return;
+        if (currentVaultIdRef.current !== currentVaultId) return;
+        // Asset baselines (see handleFileClick) only now that the workspace is
+        // known to still be this vault's: seeded during the reads, a switch
+        // mid-restore left the old vault's in the map the switch had just
+        // cleared. A document already open keeps the baseline its own open took
+        // — asked of the map itself, which every open of an asset-tracking
+        // document seeds before its setTabs and every close clears, not of
+        // tabsRef, which only catches up once a commit's effects have run.
+        // (tracksAssets keeps help, PDFs, drawings and notebooks out of the map
+        // entirely, so for those this is a no-op whichever way the test goes.)
+        for (const tab of restored) {
+          if (!assetRefsRef.current.has(tab.file.path)) rememberAssetRefs(tab.file, tab.content);
         }
+        // Which of these shared a tab as split panes. A session written before
+        // split tabs existed has no record of it, and restoreLayout gives every
+        // document a tab of its own — exactly what used to happen. The link is
+        // an instruction and the session only a default, so the link's note is
+        // what comes to the front — when it actually came back. Built out here,
+        // not in an updater, because StrictMode runs updaters twice.
+        const restoredPaths = restored.map(t => t.file.path);
+        const restoredLayout = restoreLayout(
+          restoredPaths,
+          stored?.groups,
+          stored?.focus,
+          stored?.sizes,
+          linkedNode && restoredPaths.includes(linkedNode.path) ? linkedNode.path : stored?.active ?? null,
+        );
+        // Anything opened while the reads were in flight — a click in the file
+        // tree — is MERGED, never deferred to. Deferring is what turned
+        // 5de752e's separate link opener into data loss: it opened the linked
+        // note a moment before these reads finished, this pass saw a tab and
+        // gave up, and since the refs were already claimed the persist effect
+        // filed that one tab as the vault's whole session (measured: four
+        // documents in three tabs, one a 65/35 split, came back from a reload as
+        // the one tab the address bar named, with the stored `paths` rewritten
+        // from four to that one — so every reload after it restored nothing more
+        // either). The saved tabs come first, as they were left; what was opened
+        // follows (mergeLayouts), keeping the focus; and a document open on both
+        // sides keeps its in-memory tab, which may hold edits. The gate opens
+        // BEFORE the merge is dispatched, so the commit carrying it writes the
+        // session. One ordering still writes a lone tab first: a click that
+        // committed just before this line, its effects not yet run, has them
+        // flushed ahead of the merge's render — one tab stored for the task or
+        // two until the merge's own write. flushSync would close that, but it
+        // warns on the path that never awaits (this block then runs inside the
+        // effect), and only a reload landing in that gap could cost anything.
+        release();
+        setTabs(prev => {
+          const open = new Set(prev.map(t => t.file.path));
+          return [...restored.filter(t => !open.has(t.file.path)), ...prev];
+        });
+        setLayout(prev => mergeLayouts(restoredLayout, prev));
+      } finally {
+        release();
       }
-      if (restored.length === 0) return;
-      // The reads above yield to the event loop; if the user opened something
-      // in the meantime, leave their workspace alone rather than clobber it.
-      if (tabsRef.current.length > 0) return;
-      // Or switched vaults in the meantime — the switch effect empties the tab
-      // set, so the check above would wave these through and drop the OLD
-      // vault's notes (handles and all) into the new vault's workspace. The
-      // HANDLE is checked as well as the id, and it is the half that catches it:
-      // `currentVaultId` lags `rootHandle` by a commit, so a switch whose reads
-      // land in that window passes an id test comparing the outgoing id with
-      // itself (measured: with a 600ms-per-file read, switching away mid-restore
-      // put vault A's three tabs on screen over vault B's tree, autosaving
-      // through A's handles).
-      if (rootHandleRef.current !== rootHandle) return;
-      if (currentVaultIdRef.current !== currentVaultId) return;
-      setTabs(restored);
-      // Which of these shared a tab as split panes. A session written before
-      // split tabs existed has no record of it, and restoreLayout gives every
-      // document a tab of its own — exactly what used to happen.
-      setLayout(restoreLayout(
-        restored.map(t => t.file.path),
-        stored.groups,
-        stored.focus,
-        stored.sizes,
-        stored.active,
-      ));
     })();
-  }, [fileTree, rootHandle, currentVaultId, readFile, rememberAssetRefs]);
+  }, [fileTree, rootHandle, currentVaultId, readFile, rememberAssetRefs, recentVaults, initialLocation]);
 
   // A vault taken off the recent list (the minus in the vault menu) mints a new
   // id if it is ever opened again, so its stored session would be unreachable
@@ -1470,43 +1580,6 @@ export default function App() {
     if (!sawVaultList.current) return;   // the list has not loaded yet
     pruneSessions(recentVaults.map(v => v.id));
   }, [recentVaults]);
-
-  /**
-   * Open the file the address bar names, once there is a tree to find it in.
-   *
-   * Deliberately AFTER the session restore rather than inside it: a link is an
-   * instruction and the restored session is only a default, so whatever the link
-   * names has to end up in front — and `handleFileClick` focuses what it opens,
-   * which the restore above would undo if this ran first. Its own ref gate makes
-   * it once-per-load, because the tree is rebuilt after every save.
-   */
-  /**
-   * The address bar AS THE PAGE LOADED, captured once.
-   *
-   * Not re-read later: the effect below rewrites the hash as the app settles,
-   * and one render where a vault is open but the labelled list has not caught
-   * up used to clear it — wiping the link while this was still waiting for a
-   * tree to find its file in. Reading a link that is being kept up to date is
-   * the mistake; the instruction is what arrived, once.
-   */
-  const [initialLocation] = useState(readLocation);
-
-  const linkedFileOpened = useRef(false);
-  useEffect(() => {
-    if (linkedFileOpened.current || !fileTree.length) return;
-    const wanted = initialLocation.file;
-    if (!wanted) { linkedFileOpened.current = true; return; }
-    const node = collectFiles(fileTree).find(f => f.path === wanted);
-    // Not found is not yet a failure: the tree may still be the OLD vault's,
-    // one render before the switch lands. Only give up once a vault is open and
-    // its tree has been walked.
-    if (!node) {
-      if (rootHandle) linkedFileOpened.current = true;
-      return;
-    }
-    linkedFileOpened.current = true;
-    void handleFileClick(node);
-  }, [fileTree, rootHandle, handleFileClick, initialLocation]);
 
   /**
    * Keep the address bar describing what is open, so it can be copied at any

--- a/src/utils/helpDoc.ts
+++ b/src/utils/helpDoc.ts
@@ -22,7 +22,7 @@ The folder icon at the top of the file tree remembers every folder you have open
 
 Any folder can be a vault, including one inside another vault: opening \`Notes/Maths\` gives you a vault of its own, separate from \`Notes\`. You do not need the file dialog for that — right-click the folder in the file tree and choose **Open as Vault**, and it opens as the vault straight away and joins the recent list, so the folder icon is the way back out.
 
-Switching vaults puts away the notes you had open (saving anything unsaved first), since those files belong to the vault you just left — but it does not forget them. Each vault remembers its own, so switching back brings that vault's tabs, the way they were split, the pane widths and the note you were reading straight back, without your reopening a thing. A note you deleted from disk in the meantime is simply not among them. That memory lives in this browser, beside the recent-vaults list, which is why taking a vault off that list forgets its tabs along with the row.
+Switching vaults puts away the notes you had open (saving anything unsaved first), since those files belong to the vault you just left — but it does not forget them. Each vault remembers its own, so switching back brings that vault's tabs, the way they were split, the pane widths and the note you were reading straight back, without your reopening a thing — and so does reloading the page. A note you deleted from disk in the meantime is simply not among them. That memory lives in this browser, beside the recent-vaults list, which is why taking a vault off that list forgets its tabs along with the row.
 
 ### Security & Permissions
 Modern browsers require you to explicitly grant permission every time you open a vault or sometimes when returning to the application after a session. This is a deliberate security feature of the File System Access API to ensure websites cannot silently access your hard drive.
@@ -38,6 +38,14 @@ The left sidebar displays your vault's folder structure. You can click on any \`
 The address bar tracks what is open — \`#vault=Notes&file=Math/HW1.md\` — so you
 can copy it at any moment and get back to exactly that note. Paste one into a new
 tab, bookmark it, or put it in another note.
+
+Opening a link never costs you your tabs. The vault comes back with every tab you
+had open in it, split and sized the way you left them, and the note the link names
+is brought to the front — added as one more tab if it was not open already.
+Reloading the page is the same thing, since the address bar is a link to what you
+were reading. The note half of a link only counts in the vault the link names: if
+that vault cannot be found and another one opens instead, it opens just as you
+left it.
 
 A link works on the machine and browser you opened the vault in. Browsers do not
 let a page open a folder just because it can name one, so what a link carries is

--- a/src/utils/tabGroups.ts
+++ b/src/utils/tabGroups.ts
@@ -555,3 +555,27 @@ export function restoreLayout(
     const layout: TabLayout = { groups, activeId: groups[0]?.id ?? null };
     return wantActive && available.has(wantActive) ? focusTab(layout, wantActive) : layout;
 }
+
+/**
+ * A restored session with whatever was opened while it loaded laid over it.
+ *
+ * `base` keeps its order, splits and widths; each group of `opened` follows,
+ * minus any path `base` already holds — dropped through closePath, so a split
+ * that loses a pane rescales exactly as closing that pane would have. Focus
+ * goes to what `opened` had focused (the reader's last gesture), else stays
+ * where `base` put it. Group ids are session-unique (newGroupId), so the two
+ * sets cannot collide.
+ *
+ * Merging rather than letting one side win is the point: the restore pass
+ * used to defer to anything opened during its reads, and by then it had
+ * already un-gated persistence — so deferring wrote that one tab over the
+ * whole stored session (see App's restore pass).
+ */
+export function mergeLayouts(base: TabLayout, opened: TabLayout): TabLayout {
+    if (opened.groups.length === 0) return base;
+    const wantFocus = focusedPath(opened);
+    let rest = opened;
+    for (const group of base.groups) for (const path of group.paths) rest = closePath(rest, path);
+    const merged: TabLayout = { groups: [...base.groups, ...rest.groups], activeId: base.activeId ?? rest.activeId };
+    return wantFocus ? focusTab(merged, wantFocus) : merged;
+}


### PR DESCRIPTION
Putting the open note in the URL made the page open that note on its own, a moment before the vault's saved tabs finished loading. The restore then took the note as proof the user had already opened something, gave up, and let the next save write that lone tab over the whole saved session — so a reload came back with one tab and the rest were gone for good.

The session restore is now the only thing that opens a document when a vault loads. The link's note is folded into it: appended, or focused if it is already there, and only in the vault the link actually names. A file clicked while the reads are still running merges into the restored set instead of replacing it, and nothing is persisted until that merge lands, so a click mid-load can no longer overwrite the session it was racing.