### PR TITLE
Give PDFs page thumbnails, and open annotate on the page being read

### DIFF
--- a/.agents/skills/pdf-and-drawings/SKILL.md
+++ b/.agents/skills/pdf-and-drawings/SKILL.md
@@ -166,9 +166,20 @@ requires reading it.
   comparing against the live page instead would let a scroll-while-focused yank the view back. At the
   document's bottom the box shows the last *visible* page, not the one under the top edge: a short
   final page can never reach the top edge, so otherwise jumping to it would snap the box back one.
-- **Position persistence**: the viewer tracks `{page, offset-into-page}` (+ zoom) on scroll and
-  persists it per vault path to localStorage `pdfViewPositions` (debounced); geometry changes (zoom,
-  resize, reload, the byte-swap after an annotated save) re-anchor scroll from that record.
+- **Position persistence**: `{page, offset-into-page, zoom}` per vault path, in ONE record shared
+  with the annotate canvas (`utils/pdfViewState.ts`) — pressing annotate lands on the page being read,
+  and leaving it reopens the reader where writing stopped. Geometry changes (zoom, resize, reload, the
+  byte-swap after an annotated save) re-anchor scroll from it. **The reader reads it while RENDERING**,
+  in the same commit that unmounts the canvas, so the canvas updates the in-memory record every view
+  pass (`writePdfViewPos(…, false)`) and only debounces the flush to storage; a debounced in-memory
+  write reopened the reader behind.
+- **Page thumbnails** (`components/PdfThumbnails.tsx`, both modes, toggled from the controls, open
+  state app-wide in localStorage): **windowed** (rows exist only near view; heights come from page
+  aspect ratios, so nothing is measured), **one render at a time** nearest the middle, re-decided after
+  each (a scrolled-past row is never rendered), JPEG object URLs capped at 160. The current page is
+  pushed through an **imperative handle**, never a prop — a prop would re-render the host, and for the
+  reader that is every page div. The reader keys it on `docState.gen` so a reload gets a fresh cache,
+  and its renders go straight to the document rather than through the render window's page states.
 
 ## The pen is a forked draw shape — `components/tightDrawShape.tsx`
 
@@ -249,11 +260,28 @@ selectable text.
 only ever be a bitmap; at 400% a 2x raster is mush under a pen whose ink is vector and stays crisp.
 A debounced pass re-rasterizes the pages **inside the viewport** at `zoom x devicePixelRatio`,
 stepped and capped at `MAX_PAGE_SCALE` (6x — a Letter page is then ~70MB decoded), and drops pages
-you have left back to `PAGE_RENDER_SCALE`. It is bounded to visible pages because **every** page is
-held rasterized for the canvas's life. It rides a **second, session-scoped** store listener: a pan or
-zoom must not mark the file dirty, which is also why the swap goes through `refreshPageAsset`'s
-`mergeRemoteChanges`. The pass is serialized behind an in-flight flag — overlapping runs would render
-one page at two scales and leak the loser's object URL.
+you have left back to `PAGE_RENDER_SCALE`. The swap goes through `refreshPageAsset`'s
+`mergeRemoteChanges` so it never marks the file dirty. The pass is serialized behind an in-flight flag —
+overlapping runs would render one page at two scales and leak the loser's object URL.
+
+**Pages are rasterized only as they come near the view**, nearest the middle first, re-deciding after
+each page (so jumping to page 300 renders page 300). It used to render EVERY page in order before the
+first was needed, and `zoomToFit()` on a first open — on a long PDF, every page at once, unreadably
+small. Now the camera opens on the reader's page at the reader's fit-width size (`cameraFor`), always,
+overriding the snapshot's camera, which knows nothing of where the reader has been since.
+
+**The camera is held to the document.** `setCameraOptions` constraints with `behavior: 'contain'`,
+bounds = the whole page stack, `baseZoom: 'fit-x'` and **no horizontal padding**: below fit-width the
+page is pinned centred, above it the camera clamps to the real page edges, so fit-width is edge to edge
+and zooming further simply goes further in. **Swipes are vertical-only**: a capture-phase `wheel`
+listener on `.pdf-annotate-canvas` (an ancestor of tldraw's own) swallows every non-ctrl wheel and
+applies only `deltaY`; pinches arrive as ctrl+wheel and pass through to tldraw's zoom. Because the
+bottom is clamped, the page box shows the last visible page once the view is held against the end of
+the document — the reader's rule, or typing the last page reads back an earlier one.
+
+View tracking (page box, strip, position record, the missing-page and sharpen passes) runs off a
+tldraw **`react()` on `getViewportPageBounds()`** — it fires when the view moves, not on every pointer
+move while drawing, which is what the session-scope store listener it replaced fired on.
 
 The serialize debounce is 1500ms — far longer than a drawing's 400ms — because a PDF export
 rebuilds the whole document on the main thread. `flush()` buckets shapes by page **once** (not a

--- a/src/components/PdfAnnotateCanvas.tsx
+++ b/src/components/PdfAnnotateCanvas.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Tldraw, getSnapshot, AssetRecordType, createShapeId, Box, inlineBase64AssetStore } from 'tldraw';
+import { Tldraw, getSnapshot, AssetRecordType, createShapeId, Box, inlineBase64AssetStore, react } from 'tldraw';
 import type { Editor, TLAssetId, TLAssetStore, TLEditorSnapshot, TLImageShape, TLShapeId } from 'tldraw';
 import 'tldraw/tldraw.css';
 import { pageLayout, openPdfPages, PAGE_RENDER_SCALE, type PdfPageSize, type PdfPageSource } from '../utils/pdfAnnotation';
@@ -7,6 +7,8 @@ import { setPdfRenderData } from '../utils/pdfRenderCache';
 import { isEmptyOverlay, type PageOverlay } from '../utils/pdfOverlay';
 import { svgToVectorOps } from '../utils/pdfVector';
 import { CANVAS_COMPONENTS, CANVAS_SHAPE_UTILS, applyCanvasUi, applyPenDefaults, readCanvasUi, type CanvasUiState } from './canvasPen';
+import { flushPdfViewPositions, readPdfViewPos, readThumbnailsOpen, writePdfViewPos, writeThumbnailsOpen } from '../utils/pdfViewState';
+import PdfThumbnails, { ThumbnailsToggle, type PdfThumbnailsHandle } from './PdfThumbnails';
 
 interface PdfAnnotateCanvasProps {
     filePath: string;
@@ -97,6 +99,21 @@ const PAGE_SCALE_STEP = 1;
  *  settles on, rather than at every value it passed through. */
 const REFINE_DEBOUNCE_MS = 350;
 
+/** Air above and below the document, and above a page the view is put at.
+ *  None at the sides: at fit-width a page runs edge to edge. */
+const TOP_GUTTER = 16;
+
+/** The camera that puts `box` at the top of the view, centred, at zoom `z`. */
+function cameraFor(box: { x: number; y: number; width: number; height: number }, screenWidth: number, z: number, offset = 0) {
+    return {
+        x: screenWidth / (2 * z) - (box.x + box.width / 2),
+        // Mid-page, the top edge goes back exactly where it was left; at the
+        // start of a page it gets a little air.
+        y: (offset > 0 ? 0 : TOP_GUTTER / z) - (box.y + offset * box.height),
+        z,
+    };
+}
+
 /** One page's rasterized backdrop, and how sharp it currently is. */
 interface PageImage {
     url: string;
@@ -183,6 +200,26 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
     /** Whether the user has drawn anything not yet handed to the save path. */
     const hasUnsavedRef = useRef(false);
 
+    /** Every page's box on the canvas — the same layout the save path maps
+     *  strokes back through. */
+    const boxes = useMemo(() => (pages ? pageLayout(pages) : []), [pages]);
+
+    // The page strip and the page box. The page on screen lives in refs and is
+    // written straight to the DOM by the view reaction in handleMount, never
+    // held in state: a pan would otherwise re-render this component — tldraw
+    // included — at every page boundary.
+    const [thumbsOpen, setThumbsOpen] = useState(readThumbnailsOpen);
+    useEffect(() => { writeThumbnailsOpen(thumbsOpen); }, [thumbsOpen]);
+    /** Where the strip opens: the reader's page on mount, the current one on a toggle. */
+    const [thumbsStart, setThumbsStart] = useState(0);
+    const thumbsRef = useRef<PdfThumbnailsHandle | null>(null);
+    const pageInputRef = useRef<HTMLInputElement | null>(null);
+    const pageInputFocusValueRef = useRef('');
+    /** 0-based page under the top of the view. */
+    const shownPageRef = useRef(0);
+    /** The box tldraw lives in — where swipes are caught before tldraw sees them. */
+    const canvasWrapRef = useRef<HTMLDivElement | null>(null);
+
     /**
      * Page images are resolved at render time rather than stored.
      *
@@ -225,14 +262,17 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
                 // asset store to resolve page URLs through this ref.
                 pageImagesRef.current = images;
                 sourceRef.current = source;
+                // The page the reader was on, for the strip to open at. Read
+                // here, after an await, rather than while rendering: the reader
+                // records its position as it unmounts.
+                const start = Math.min(source.sizes.length - 1, readPdfViewPos(filePath)?.page ?? 0);
+                shownPageRef.current = start;
+                setThumbsStart(start);
                 setPages(source.sizes);
-
-                for (let i = 0; i < source.sizes.length; i++) {
-                    const url = await source.renderPage(i);
-                    if (cancelled) { URL.revokeObjectURL(url); return; }
-                    images[i] = { url, scale: PAGE_RENDER_SCALE };
-                    refreshPageAsset(editorRef.current, i);
-                }
+                // Nothing is rasterized here. It used to be EVERY page, in order,
+                // before the first one was needed — on a 300-page book, 300 renders
+                // and JPEG encodes to show the one you opened on. Pages are drawn
+                // as they come near the view instead; see refinePages.
             } catch (err) {
                 console.error('Could not render PDF pages:', err);
                 if (!cancelled) setError(err instanceof Error ? err.message : String(err));
@@ -246,12 +286,11 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
             for (const image of images) if (image) URL.revokeObjectURL(image.url);
             void source?.close();
         };
-    }, [original]);
+    }, [original, filePath]);
 
     const handleMount = useCallback((editor: Editor) => {
         if (!pages) return;
         editorRef.current = editor;
-        const boxes = pageLayout(pages);
 
         // Add the page backdrops ONLY if the snapshot didn't already bring them.
         //
@@ -316,17 +355,69 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
             editor.sendToBack(pageShapeIds);
         }
 
-        // Frame the document only on a first-ever open. On a reopen the snapshot
-        // restores the camera, and fitting would throw away where the user was.
-        if (!parsed.snapshot) editor.zoomToFit();
+        // Open on the page being READ, at the reader's size — not on the whole
+        // document. This used to zoomToFit() on a first open, which on a long PDF
+        // is every page at once, too small to read or write on; and a reopen
+        // restored the snapshot's camera, which knew nothing of where the reader
+        // had got to since. The position record is shared with the reader
+        // (utils/pdfViewState.ts), so the two modes hand one page back and forth.
+        const maxPageWidth = Math.max(...pages.map(p => p.width));
+        const docBottom = boxes[boxes.length - 1].y + boxes[boxes.length - 1].height;
+        const fitZoom = () => Math.max(0.05, editor.getViewportScreenBounds().width / maxPageWidth);
+
+        // The view cannot leave the document. tldraw's canvas is infinite, which
+        // is how a swipe could carry the page clean off screen. `contain`: below
+        // fit-width the page is pinned, centred; above it, the camera is clamped
+        // to the document's real edges — so fit-width is the page edge to edge,
+        // and zooming further just goes further in. Vertically the same, with a
+        // little air at the very top and bottom.
+        editor.setCameraOptions({
+            constraints: {
+                bounds: { x: 0, y: 0, w: maxPageWidth, h: docBottom },
+                padding: { x: 0, y: TOP_GUTTER },
+                origin: { x: 0.5, y: 0 },
+                initialZoom: 'fit-x',
+                baseZoom: 'fit-x',
+                behavior: 'contain',
+            },
+        });
+
+        // Two-finger swipes scroll the document up and down and do nothing else,
+        // the way a PDF scrolls — tldraw would pan on both axes. A pinch arrives
+        // as a ctrl+wheel and is left to tldraw's own zoom. Caught in the CAPTURE
+        // phase on an ancestor, so tldraw's wheel handler never sees a swipe.
+        const wrap = canvasWrapRef.current;
+        const onWheel = (e: WheelEvent) => {
+            if (e.ctrlKey || e.metaKey) return;
+            // A long tldraw menu scrolls itself.
+            if ((e.target as Element | null)?.closest?.('.tlui-menu, .tlui-popover__content')) return;
+            e.preventDefault();
+            e.stopPropagation();
+            const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? editor.getViewportScreenBounds().height : 1;
+            const { x, y, z } = editor.getCamera();
+            editor.setCamera({ x, y: y - (e.deltaY * unit) / z, z });
+        };
+        wrap?.addEventListener('wheel', onWheel, { capture: true, passive: false });
+        const savedPos = readPdfViewPos(filePath);
+        editor.setCamera(cameraFor(
+            boxes[Math.min(boxes.length - 1, savedPos?.page ?? 0)],
+            editor.getViewportScreenBounds().width,
+            fitZoom() * (savedPos?.zoom ?? 1),
+            savedPos?.offset ?? 0,
+        ));
 
         for (const shape of editor.getCurrentPageShapes()) {
             if (shape.meta?.pdfPage !== undefined) pageShapeIdsRef.current.add(shape.id);
         }
 
         /**
-         * Bring the pages you can see up to the zoom you are looking at them at,
-         * and let the ones you have left go back to the base scale.
+         * Keep the backdrop true to the view: rasterize pages as they come near
+         * it, sharpen the ones in it to the zoom they are seen at, and let pages
+         * that have been left drop back to the base scale.
+         *
+         * Nothing is rasterized ahead of need. Pages near the view come first,
+         * nearest the middle first, deciding again after EVERY page — so jumping
+         * to page 300 renders page 300, not 1 through 299 on the way there.
          *
          * Serialized behind `refining`, not merely started: rasterizing a page is
          * a worker round-trip plus a JPEG encode, and a zoom gesture can queue
@@ -335,16 +426,55 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
          */
         let refining = false;
         let refineAgain = false;
-        const refinePages = async () => {
+        let sharpenWanted = false;
+        const unrenderable = new Set<number>();
+        const refinePages = async (sharpen: boolean) => {
+            if (sharpen) sharpenWanted = true;
             if (refining) { refineAgain = true; return; }
             const source = sourceRef.current;
             const images = pageImagesRef.current;
-            if (!source || !images.length) return;
+            if (!source) return;
 
             refining = true;
             try {
                 do {
                     refineAgain = false;
+                    const viewport = editor.getViewportPageBounds();
+
+                    // 1. The nearest never-drawn page within a screen of the view.
+                    //    One per iteration, then look again: the view may have
+                    //    moved while it rendered.
+                    const reach = viewport.height;
+                    const middle = (viewport.minY + viewport.maxY) / 2;
+                    let missing = -1;
+                    for (let i = 0, best = Infinity; i < boxes.length; i++) {
+                        const box = boxes[i];
+                        if (images[i] || unrenderable.has(i)) continue;
+                        if (box.y > viewport.maxY + reach || box.y + box.height < viewport.minY - reach) continue;
+                        const distance = Math.abs(box.y + box.height / 2 - middle);
+                        if (distance < best) { best = distance; missing = i; }
+                    }
+                    if (missing >= 0) {
+                        try {
+                            const url = await source.renderPage(missing);
+                            // The canvas may have gone away mid-render; the cleanup
+                            // has already emptied the array, so this URL is ours to
+                            // drop rather than ours to install.
+                            if (pageImagesRef.current !== images) { URL.revokeObjectURL(url); return; }
+                            images[missing] = { url, scale: PAGE_RENDER_SCALE };
+                            refreshPageAsset(editor, missing);
+                        } catch (err) {
+                            // Left blank rather than retried on every pan.
+                            unrenderable.add(missing);
+                            console.warn(`Could not render PDF page ${missing + 1}:`, err);
+                        }
+                        refineAgain = true;
+                        continue;
+                    }
+
+                    // 2. Sharpen, once the view has settled (see scheduleRefine).
+                    if (!sharpenWanted) continue;
+                    sharpenWanted = false;
                     // Zoom is CSS pixels per page unit; the display adds its own
                     // ratio on top, and it is the product that a raster has to
                     // match to look sharp.
@@ -355,26 +485,18 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
                             Math.ceil((editor.getZoomLevel() * window.devicePixelRatio) / PAGE_SCALE_STEP) * PAGE_SCALE_STEP,
                         ),
                     );
-                    const viewport = editor.getViewportPageBounds();
-
                     for (let i = 0; i < boxes.length; i++) {
                         const box = boxes[i];
                         const current = images[i];
-                        // Not yet rasterized at all — the streaming load owns it.
                         if (!current) continue;
-
                         const visible = box.y < viewport.maxY && box.y + box.height > viewport.minY
                             && box.x < viewport.maxX && box.x + box.width > viewport.minX;
                         const target = visible ? wanted : PAGE_RENDER_SCALE;
                         if (current.scale === target) continue;
-
                         // Dropping back to base is a re-render too, but a cheap
                         // one, and it is what returns the memory a zoomed-in page
                         // borrowed.
                         const url = await source.renderPage(i, target);
-                        // The canvas may have gone away mid-render; the cleanup
-                        // has already emptied the array, so this URL is ours to
-                        // drop rather than ours to install.
                         if (pageImagesRef.current !== images) { URL.revokeObjectURL(url); return; }
                         URL.revokeObjectURL(current.url);
                         images[i] = { url, scale: target };
@@ -390,16 +512,70 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
             }
         };
 
+        // Sharpening waits for the view to settle: a zoom gesture passes through
+        // every scale on the way, and rendering each one would be wasted work.
         let refineTimer: ReturnType<typeof setTimeout> | null = null;
         const scheduleRefine = () => {
             if (refineTimer) clearTimeout(refineTimer);
-            refineTimer = setTimeout(() => { refineTimer = null; void refinePages(); }, REFINE_DEBOUNCE_MS);
+            refineTimer = setTimeout(() => { refineTimer = null; void refinePages(true); }, REFINE_DEBOUNCE_MS);
         };
-        // Session scope is where the camera lives, and it is deliberately a
-        // different listener from the save one below: a pan or a zoom must
-        // refine the backdrop WITHOUT marking the file dirty.
-        const unlistenCamera = editor.store.listen(scheduleRefine, { scope: 'session' });
-        scheduleRefine();   // the snapshot may have restored a zoomed-in camera
+
+        /** First page whose bottom edge is below `y`. A gap between pages counts
+         *  as the page after it, as it does in the reader. */
+        const pageAt = (y: number) => {
+            let lo = 0, hi = boxes.length - 1;
+            while (lo < hi) {
+                const mid = (lo + hi) >> 1;
+                if (boxes[mid].y + boxes[mid].height <= y) lo = mid + 1;
+                else hi = mid;
+            }
+            return lo;
+        };
+
+        // Where the view is: for the page box, the strip, and the record the
+        // reader reopens from. The record changes in memory on every pass and
+        // reaches storage on a debounce — see writePdfViewPos for why memory
+        // cannot be the one that lags.
+        let persistTimer: ReturnType<typeof setTimeout> | null = null;
+        const trackView = () => {
+            const view = editor.getViewportPageBounds();
+            const page = pageAt(view.minY);
+            const box = boxes[page];
+            // The page SHOWN is the one under the top edge — except once the view
+            // is held against the end of a document taller than it, where the
+            // last pages can never reach the top, and typing "40" would otherwise
+            // read back "38". Same rule as the reader.
+            const shown = view.maxY >= docBottom && view.height < docBottom ? pageAt(view.maxY - 1) : page;
+            const input = pageInputRef.current;
+            if (shown !== shownPageRef.current || (input && !input.value)) {
+                shownPageRef.current = shown;
+                if (input && document.activeElement !== input) input.value = String(shown + 1);
+                thumbsRef.current?.setCurrentPage(shown);
+            }
+            writePdfViewPos(filePath, {
+                page,
+                offset: Math.min(1, Math.max(0, (view.minY - box.y) / box.height)),
+                zoom: editor.getZoomLevel() / fitZoom(),
+            }, false);
+            if (persistTimer) clearTimeout(persistTimer);
+            persistTimer = setTimeout(() => { persistTimer = null; flushPdfViewPositions(); }, 400);
+        };
+
+        // Reads only the camera and the viewport's size, so this runs when the
+        // VIEW moves — not on every pointer move while drawing, which is what
+        // the session-scope store listener it replaces fired on.
+        let viewFrame = 0;
+        const stopViewReaction = react('pdf annotate view', () => {
+            editor.getViewportPageBounds();
+            if (!viewFrame) {
+                viewFrame = requestAnimationFrame(() => {
+                    viewFrame = 0;
+                    trackView();
+                    void refinePages(false);
+                });
+            }
+            scheduleRefine();
+        });
 
         /**
          * @param immediate true when the canvas is going away (mode toggle, tab
@@ -533,8 +709,11 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
         return () => {
             unlisten();
             disposePen();
-            unlistenCamera();
+            stopViewReaction();
+            cancelAnimationFrame(viewFrame);
+            wrap?.removeEventListener('wheel', onWheel, { capture: true });
             if (refineTimer) clearTimeout(refineTimer);
+            if (persistTimer) { clearTimeout(persistTimer); flushPdfViewPositions(); }
             if (serializeTimerRef.current) clearTimeout(serializeTimerRef.current);
             // Write on the way out so the viewer (which re-reads immediately) sees
             // the strokes — but only if there are any. Flushing unconditionally
@@ -544,7 +723,44 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
                 void flush(true);
             }
         };
-    }, [filePath, original, pages, parsed.snapshot]);
+    }, [filePath, original, pages, boxes]);
+
+    const renderThumbnail = useCallback((index: number, scale: number) => {
+        const source = sourceRef.current;
+        return source ? source.renderPage(index, scale) : Promise.reject(new Error('The PDF is closed'));
+    }, []);
+
+    /** Put page `index` at the top of the view, centred, at the current zoom. */
+    const jumpToPage = useCallback((index: number) => {
+        const editor = editorRef.current;
+        if (!editor || boxes.length === 0) return;
+        const box = boxes[Math.min(boxes.length - 1, Math.max(0, index))];
+        editor.setCamera(cameraFor(box, editor.getViewportScreenBounds().width, editor.getZoomLevel()));
+    }, [boxes]);
+
+    const resetPageInput = useCallback(() => {
+        const input = pageInputRef.current;
+        if (input) input.value = String(shownPageRef.current + 1);
+    }, []);
+
+    /** Go to the typed page. Out of range clamps — "999" in a 40-page document
+     *  plainly means the end — and anything unreadable puts the box back. */
+    const commitPageInput = useCallback((onlyIfChanged: boolean) => {
+        const input = pageInputRef.current;
+        if (!input || (onlyIfChanged && input.value === pageInputFocusValueRef.current)) return;
+        const typed = Number.parseInt(input.value, 10);
+        if (!Number.isFinite(typed)) { resetPageInput(); return; }
+        const page = Math.min(boxes.length, Math.max(1, typed));
+        input.value = String(page);
+        // So the blur that follows an Enter does not jump a second time.
+        pageInputFocusValueRef.current = input.value;
+        jumpToPage(page - 1);
+    }, [boxes.length, jumpToPage, resetPageInput]);
+
+    const toggleThumbs = useCallback(() => {
+        setThumbsStart(shownPageRef.current);
+        setThumbsOpen(open => !open);
+    }, []);
 
     if (error) {
         return (
@@ -559,16 +775,63 @@ export default function PdfAnnotateCanvas({ filePath, original, snapshot, onCont
     }
 
     return (
-        <div className="drawing-pane pdf-annotate-pane">
-            <Tldraw
-                snapshot={parsed.snapshot}
-                assets={assetStore}
-                onMount={handleMount}
-                components={CANVAS_COMPONENTS}
-                shapeUtils={CANVAS_SHAPE_UTILS}
-                colorScheme={ANNOTATE_COLOR_SCHEME}
-                licenseKey={import.meta.env.VITE_TLDRAW_LICENSE_KEY}
-            />
+        <div className={`drawing-pane pdf-annotate-pane${thumbsOpen ? ' has-thumbs' : ''}`}>
+            {thumbsOpen && (
+                <PdfThumbnails
+                    ref={thumbsRef}
+                    sizes={pages}
+                    renderThumbnail={renderThumbnail}
+                    onSelect={jumpToPage}
+                    initialPage={thumbsStart}
+                />
+            )}
+            <div className="pdf-annotate-canvas" ref={canvasWrapRef}>
+                <Tldraw
+                    snapshot={parsed.snapshot}
+                    assets={assetStore}
+                    onMount={handleMount}
+                    components={CANVAS_COMPONENTS}
+                    shapeUtils={CANVAS_SHAPE_UTILS}
+                    colorScheme={ANNOTATE_COLOR_SCHEME}
+                    licenseKey={import.meta.env.VITE_TLDRAW_LICENSE_KEY}
+                />
+            </div>
+            <div className="pdf-viewer-controls">
+                <div className="pdf-viewer-pill">
+                    <ThumbnailsToggle open={thumbsOpen} onToggle={toggleThumbs} />
+                </div>
+                <div className="pdf-viewer-pill pdf-viewer-pages">
+                    <input
+                        ref={pageInputRef}
+                        className="pdf-viewer-page-input"
+                        type="text"
+                        inputMode="numeric"
+                        autoComplete="off"
+                        spellCheck={false}
+                        style={{ width: `${Math.max(2, String(pages.length).length)}ch` }}
+                        title="Current page — type a number and press Enter to jump"
+                        aria-label="Page number"
+                        onFocus={e => {
+                            pageInputFocusValueRef.current = e.currentTarget.value;
+                            e.currentTarget.select();
+                        }}
+                        onKeyDown={e => {
+                            // Digits and Backspace are tldraw shortcuts too.
+                            e.stopPropagation();
+                            if (e.key === 'Enter') {
+                                commitPageInput(false);
+                                e.currentTarget.blur();
+                            } else if (e.key === 'Escape') {
+                                resetPageInput();
+                                pageInputFocusValueRef.current = e.currentTarget.value;
+                                e.currentTarget.blur();
+                            }
+                        }}
+                        onBlur={() => commitPageInput(true)}
+                    />
+                    <span className="pdf-viewer-page-total">/ {pages.length}</span>
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/components/PdfThumbnails.tsx
+++ b/src/components/PdfThumbnails.tsx
@@ -1,0 +1,251 @@
+// Page thumbnails: a narrow strip down the left edge of a PDF, shared by the
+// reader (PdfViewer) and the annotate canvas.
+//
+// Built so a 1,000-page document costs what a 10-page one does:
+//
+//  · WINDOWED. Only the rows in view, plus OVERSCAN either side, exist in the
+//    DOM. Every row's height follows from its page's aspect ratio, so the
+//    strip's scroll height and each row's position are arithmetic, never a
+//    layout measurement.
+//  · ONE RENDER AT A TIME, nearest the middle of the view first, re-deciding
+//    after every render. A row scrolled past before its turn is simply never
+//    rendered, instead of a queue of hundreds of stale requests working through
+//    the same pdf.js worker the page you are reading needs.
+//  · JPEG OBJECT URLS, CAPPED. A thumbnail is a few KB as a JPEG and ~250KB as
+//    a live canvas bitmap; past MAX_CACHED the rows farthest from view are let
+//    go and simply re-rendered if you scroll back.
+//  · THE CURRENT PAGE ARRIVES THROUGH A HANDLE, NOT A PROP. Scrolling the
+//    document re-renders this strip — two dozen rows — and never the host: the
+//    reader keeps its page number out of React state for exactly this reason,
+//    since re-rendering it means re-rendering every page div.
+//
+// Keyed by its host on the document, so `sizes` and `renderThumbnail` are fixed
+// for the life of one strip and a reloaded document gets a fresh cache.
+
+import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+export interface PdfThumbnailsHandle {
+    /** Mark `index` as the page on screen and bring its row into view. */
+    setCurrentPage(index: number): void;
+}
+
+interface PdfThumbnailsProps {
+    /** Every page's size at scale 1. Only the aspect ratio matters here. */
+    sizes: ReadonlyArray<{ width: number; height: number }>;
+    /** Rasterize page `index` (0-based) at `scale` to an object URL, which the
+     *  strip then owns and revokes. */
+    renderThumbnail: (index: number, scale: number) => Promise<string>;
+    onSelect: (index: number) => void;
+    initialPage: number;
+}
+
+/** CSS width of a thumbnail. The strip is this plus its padding — see
+ *  --pdf-thumbs-width, which must agree. */
+const THUMB_WIDTH = 108;
+const LABEL_HEIGHT = 22;
+const ROW_GAP = 10;
+const PAD = 12;
+const OVERSCAN = 3;
+const MAX_CACHED = 160;
+
+function PdfThumbnails({ sizes, renderThumbnail, onSelect, initialPage }: PdfThumbnailsProps, ref: React.ForwardedRef<PdfThumbnailsHandle>) {
+    const n = sizes.length;
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+
+    const geometry = useMemo(() => {
+        const imageHeights: number[] = [];
+        const tops: number[] = [];
+        let y = PAD;
+        for (const size of sizes) {
+            const h = Math.round(THUMB_WIDTH * (size.height / (size.width || 1)));
+            imageHeights.push(h);
+            tops.push(y);
+            y += h + LABEL_HEIGHT + ROW_GAP;
+        }
+        return { imageHeights, tops, total: y - ROW_GAP + PAD };
+    }, [sizes]);
+
+    const clampPage = useCallback((i: number) => Math.min(n - 1, Math.max(0, i)), [n]);
+    const [current, setCurrent] = useState(() => clampPage(initialPage));
+    const currentRef = useRef(current);
+    const [range, setRange] = useState({ from: 0, to: Math.min(n - 1, 8) });
+    const rangeRef = useRef(range);
+    const [, setVersion] = useState(0);
+
+    const urlsRef = useRef<Map<number, string>>(new Map());
+    const failedRef = useRef<Set<number>>(new Set());
+    const aliveRef = useRef(true);
+    const pumpingRef = useRef(false);
+    const renderRef = useRef(renderThumbnail);
+    useEffect(() => { renderRef.current = renderThumbnail; }, [renderThumbnail]);
+
+    /** First row whose bottom edge is below `y`. */
+    const rowAt = useCallback((y: number) => {
+        const { tops, imageHeights } = geometry;
+        let lo = 0, hi = n - 1;
+        while (lo < hi) {
+            const mid = (lo + hi) >> 1;
+            if (tops[mid] + imageHeights[mid] + LABEL_HEIGHT < y) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
+    }, [geometry, n]);
+
+    const evict = useCallback(() => {
+        const urls = urlsRef.current;
+        if (urls.size <= MAX_CACHED) return;
+        const { from, to } = rangeRef.current;
+        const mid = (from + to) / 2;
+        const farthest = [...urls.keys()].sort((a, b) => Math.abs(b - mid) - Math.abs(a - mid));
+        for (const i of farthest.slice(0, urls.size - MAX_CACHED)) {
+            URL.revokeObjectURL(urls.get(i)!);
+            urls.delete(i);
+        }
+    }, []);
+
+    const pump = useCallback(async () => {
+        if (pumpingRef.current) return;
+        pumpingRef.current = true;
+        try {
+            for (;;) {
+                if (!aliveRef.current) return;
+                const { from, to } = rangeRef.current;
+                const mid = (from + to) / 2;
+                let next = -1;
+                for (let i = Math.max(0, from - OVERSCAN), best = Infinity; i <= Math.min(n - 1, to + OVERSCAN); i++) {
+                    if (urlsRef.current.has(i) || failedRef.current.has(i)) continue;
+                    if (Math.abs(i - mid) < best) { best = Math.abs(i - mid); next = i; }
+                }
+                if (next < 0) return;
+                const dpr = Math.min(2, Math.max(1, window.devicePixelRatio || 1));
+                try {
+                    const url = await renderRef.current(next, (THUMB_WIDTH * dpr) / (sizes[next].width || 1));
+                    if (!aliveRef.current) { URL.revokeObjectURL(url); return; }
+                    urlsRef.current.set(next, url);
+                    evict();
+                    setVersion(v => v + 1);
+                } catch (err) {
+                    // A page that will not rasterize keeps its blank frame rather
+                    // than being retried on every scroll.
+                    failedRef.current.add(next);
+                    if (aliveRef.current) console.warn(`Could not render the thumbnail for page ${next + 1}:`, err);
+                }
+            }
+        } finally {
+            pumpingRef.current = false;
+        }
+    }, [n, sizes, evict]);
+
+    const measure = useCallback(() => {
+        const el = scrollRef.current;
+        if (!el || n === 0) return;
+        const from = rowAt(el.scrollTop);
+        const to = Math.min(n - 1, rowAt(el.scrollTop + el.clientHeight));
+        if (from !== rangeRef.current.from || to !== rangeRef.current.to) {
+            rangeRef.current = { from, to };
+            setRange({ from, to });
+        }
+        void pump();
+    }, [n, rowAt, pump]);
+
+    const frameRef = useRef(0);
+    const onScroll = useCallback(() => {
+        if (frameRef.current) return;
+        frameRef.current = requestAnimationFrame(() => { frameRef.current = 0; measure(); });
+    }, [measure]);
+
+    /** Scroll the strip just enough to show row `i`, if it is not already shown. */
+    const reveal = useCallback((i: number) => {
+        const el = scrollRef.current;
+        if (!el) return;
+        const top = geometry.tops[i];
+        const bottom = top + geometry.imageHeights[i] + LABEL_HEIGHT;
+        if (top < el.scrollTop) el.scrollTop = top - PAD;
+        else if (bottom > el.scrollTop + el.clientHeight) el.scrollTop = bottom - el.clientHeight + PAD;
+    }, [geometry]);
+
+    useImperativeHandle(ref, () => ({
+        setCurrentPage(index: number) {
+            const i = clampPage(index);
+            if (i === currentRef.current) return;
+            currentRef.current = i;
+            setCurrent(i);
+            reveal(i);
+        },
+    }), [clampPage, reveal]);
+
+    // Open on the page being read, then keep the visible range true as the
+    // strip itself is resized (a window resize, a split being dragged).
+    useLayoutEffect(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        const i = currentRef.current;
+        el.scrollTop = Math.max(0, geometry.tops[i] - el.clientHeight / 2 + geometry.imageHeights[i] / 2);
+        measure();
+        const observer = new ResizeObserver(() => measure());
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [geometry, measure]);
+
+    useEffect(() => {
+        aliveRef.current = true;
+        const urls = urlsRef.current;
+        return () => {
+            aliveRef.current = false;
+            cancelAnimationFrame(frameRef.current);
+            for (const url of urls.values()) URL.revokeObjectURL(url);
+            urls.clear();
+        };
+    }, []);
+
+    const rows: number[] = [];
+    for (let i = Math.max(0, range.from - OVERSCAN); i <= Math.min(n - 1, range.to + OVERSCAN); i++) rows.push(i);
+
+    return (
+        <nav className="pdf-thumbs" ref={scrollRef} onScroll={onScroll} aria-label="Pages">
+            <div className="pdf-thumbs-inner" style={{ height: geometry.total }}>
+                {rows.map(i => {
+                    const url = urlsRef.current.get(i);
+                    return (
+                        <button
+                            key={i}
+                            type="button"
+                            className={`pdf-thumb${i === current ? ' is-current' : ''}`}
+                            style={{ top: geometry.tops[i], width: THUMB_WIDTH }}
+                            onClick={() => onSelect(i)}
+                            aria-label={`Page ${i + 1}`}
+                            aria-current={i === current ? 'page' : undefined}
+                        >
+                            <span className="pdf-thumb-page" style={{ height: geometry.imageHeights[i] }}>
+                                {url && <img src={url} alt="" draggable={false} />}
+                            </span>
+                            <span className="pdf-thumb-label">{i + 1}</span>
+                        </button>
+                    );
+                })}
+            </div>
+        </nav>
+    );
+}
+
+/** The button that opens and closes the strip — one component so the reader
+ *  and the annotate canvas cannot drift apart. */
+export function ThumbnailsToggle({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+    return (
+        <button
+            type="button"
+            className={`pdf-viewer-thumbs-toggle${open ? ' is-on' : ''}`}
+            onClick={onToggle}
+            title={open ? 'Hide page thumbnails' : 'Show page thumbnails'}
+            aria-label="Page thumbnails"
+            aria-pressed={open}
+        >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect width="18" height="18" x="3" y="3" rx="2" />
+                <path d="M9 3v18" />
+            </svg>
+        </button>
+    );
+}
+
+export default memo(forwardRef(PdfThumbnails));

--- a/src/components/PdfViewer.tsx
+++ b/src/components/PdfViewer.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as pdfjs from 'pdfjs-dist';
 import type { PDFDocumentProxy, PDFPageProxy, RenderTask } from 'pdfjs-dist';
-import { readRecord, flushRecord, scopedKey } from '../utils/storage';
+import { readPdfViewPos, readThumbnailsOpen, writePdfViewPos, writeThumbnailsOpen } from '../utils/pdfViewState';
+import PdfThumbnails, { ThumbnailsToggle, type PdfThumbnailsHandle } from './PdfThumbnails';
 import { readPageLinks, resolveDestination } from '../utils/pdfLinks';
 import { pdfWorker } from '../utils/pdfWorker';
 import type { PdfLink, PdfLinkTarget } from '../utils/pdfLinks';
@@ -53,15 +54,6 @@ interface PdfViewerProps {
     isActive: boolean;
 }
 
-interface PdfViewPos {
-    /** 0-based index of the page under the top edge of the viewport. */
-    page: number;
-    /** How far into that page the top edge sits, as a fraction of its height. */
-    offset: number;
-    /** Zoom factor on top of fit-width (1 = fit width). */
-    zoom?: number;
-}
-
 interface DocState {
     doc: PDFDocumentProxy;
     /** Per-page size at scale 1, in PDF points. */
@@ -93,7 +85,6 @@ interface PageState {
     linksPromise?: Promise<void>;
 }
 
-const STORAGE_KEY = 'pdfViewPositions';
 /** Vertical padding above the first / below the last page, px. */
 const PAD_V = 20;
 /** Gap between pages, px. */
@@ -298,9 +289,7 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
     // Read once per mount: where this file was last left, and at what zoom.
     // Keyed by vault as well as path — two vaults can both hold `refs/spec.pdf`
     // and page 47 of one is nowhere in the other (see utils/storage.ts).
-    const [saved] = useState<PdfViewPos | undefined>(
-        () => readRecord<PdfViewPos>(STORAGE_KEY)[scopedKey(filePath)]
-    );
+    const [saved] = useState(() => readPdfViewPos(filePath));
     const [zoom, setZoom] = useState<number>(() => clampZoom(saved?.zoom ?? 1));
     const [docState, setDocState] = useState<DocState | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -330,6 +319,13 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
     /** The 0-based page the box is displaying. Usually the page under the top
      *  edge, but not at the document's bottom — see updateWindow. */
     const shownPageRef = useRef(0);
+    /** The page strip, and the page it opens on. Its current page is pushed
+     *  through the handle from the scroll pass, never through a prop — see
+     *  components/PdfThumbnails.tsx for why. */
+    const [thumbsOpen, setThumbsOpen] = useState(readThumbnailsOpen);
+    const [thumbsStart, setThumbsStart] = useState(() => saved?.page ?? 0);
+    const thumbsRef = useRef<PdfThumbnailsHandle | null>(null);
+    useEffect(() => { writeThumbnailsOpen(thumbsOpen); }, [thumbsOpen]);
     const pageStatesRef = useRef<Map<number, PageState>>(new Map());
     const textLayersRef = useRef<Set<InstanceType<typeof pdfjs.TextLayer>>>(new Set());
     const docStateRef = useRef<DocState | null>(null);
@@ -348,11 +344,8 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
     const persistTimerRef = useRef<number | null>(null);
     const persistNow = useCallback(() => {
         persistTimerRef.current = null;
-        // The record is held parsed in memory — mutate and write, no re-parse.
-        const all = readRecord<PdfViewPos>(STORAGE_KEY);
         const { page, offset } = currentPosRef.current;
-        all[scopedKey(filePath)] = { page, offset: Math.round(offset * 1000) / 1000, zoom: zoomRef.current };
-        flushRecord(STORAGE_KEY);
+        writePdfViewPos(filePath, { page, offset, zoom: zoomRef.current });
     }, [filePath]);
 
     const schedulePersist = useCallback(() => {
@@ -561,6 +554,45 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
         // page i, where "which page is under the top edge" still answers i-1.
         // Jumping to page 9 would then leave the box reading 8.
         el.scrollTop = Math.ceil(L.tops[i] + offset * L.scale);
+    }, []);
+
+    /**
+     * One page for the thumbnail strip, as a small JPEG.
+     *
+     * Straight from the document, not through the render window: a thumbnail
+     * must not take a canvas slot or a page state that the scroll pass evicts
+     * and cleans up on its own schedule. It lets pdf.js drop what it parsed for
+     * the page afterwards — unless the reader is holding that page, in which
+     * case the reader's own cleanup decides.
+     */
+    const renderThumbnail = useCallback(async (index: number, scale: number) => {
+        const doc = docStateRef.current?.doc;
+        if (!doc) throw new Error('The document is not open');
+        const page = await doc.getPage(index + 1);
+        const viewport = page.getViewport({ scale });
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.ceil(viewport.width));
+        canvas.height = Math.max(1, Math.ceil(viewport.height));
+        const ctx = canvas.getContext('2d');
+        if (!ctx) throw new Error('No 2D canvas context for a thumbnail');
+        await page.render({ canvas, canvasContext: ctx, viewport }).promise;
+        const blob = await new Promise<Blob | null>(res => canvas.toBlob(res, 'image/jpeg', 0.8));
+        canvas.width = 0;
+        canvas.height = 0;
+        const st = pageStatesRef.current.get(index);
+        if (!st?.pagePromise || st.cleaned) page.cleanup();
+        if (!blob) throw new Error('Could not encode a thumbnail');
+        return URL.createObjectURL(blob);
+    }, []);
+
+    const thumbSizes = useMemo(
+        () => docState?.dims.map(d => ({ width: d.w, height: d.h })) ?? [],
+        [docState],
+    );
+
+    const toggleThumbs = useCallback(() => {
+        setThumbsStart(shownPageRef.current);
+        setThumbsOpen(open => !open);
     }, []);
 
     /** Act on a clicked link: jump to its destination, or run its named action.
@@ -825,6 +857,7 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
         const maxScroll = el.scrollHeight - el.clientHeight;
         const shown = maxScroll > 1 && top >= maxScroll - 1 ? last : first;
         shownPageRef.current = shown;
+        thumbsRef.current?.setCurrentPage(shown);
         // Written straight to the DOM rather than through state — see
         // pageInputRef. Never while it's focused: that would fight the typing.
         const input = pageInputRef.current;
@@ -1126,7 +1159,17 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
     }
 
     return (
-        <div className="pdf-viewer" ref={rootRef}>
+        <div className={`pdf-viewer${thumbsOpen ? ' has-thumbs' : ''}`} ref={rootRef}>
+            {thumbsOpen && docState && (
+                <PdfThumbnails
+                    key={docState.gen}
+                    ref={thumbsRef}
+                    sizes={thumbSizes}
+                    renderThumbnail={renderThumbnail}
+                    onSelect={scrollToPage}
+                    initialPage={thumbsStart}
+                />
+            )}
             <div
                 className="pdf-viewer-scroll"
                 ref={scrollRef}
@@ -1164,6 +1207,9 @@ function PdfViewer({ filePath, data, isActive }: PdfViewerProps) {
             </div>
             {layout && (
                 <div className="pdf-viewer-controls">
+                    <div className="pdf-viewer-pill">
+                        <ThumbnailsToggle open={thumbsOpen} onToggle={toggleThumbs} />
+                    </div>
                     <div className="pdf-viewer-pill pdf-viewer-pages">
                         <input
                             ref={pageInputRef}

--- a/src/index.css
+++ b/src/index.css
@@ -2133,6 +2133,122 @@ body.is-resizing-panes * {
   user-select: none;
 }
 
+/* ── Page thumbnails (PdfThumbnails.tsx) — the reader and the annotate canvas ──
+   The strip is windowed and absolutely positioned; the document beside it just
+   starts where the strip ends. */
+.pdf-viewer,
+.pdf-annotate-pane {
+  /* THUMB_WIDTH (108) plus 14px either side — keep the two in step. */
+  --pdf-thumbs-width: 136px;
+}
+
+.pdf-thumbs {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--pdf-thumbs-width);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  background: var(--background-secondary);
+  border-right: 1px solid var(--background-modifier-border);
+  z-index: 6;
+}
+
+.pdf-thumbs-inner {
+  position: relative;
+}
+
+.pdf-thumb {
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.pdf-thumb-page {
+  display: block;
+  overflow: hidden;
+  border-radius: 2px;
+  background: #fff;
+  box-shadow: 0 0 0 1px var(--background-modifier-border), 0 1px 3px rgba(0, 0, 0, 0.25);
+  transition: box-shadow 0.12s ease;
+}
+
+.pdf-thumb-page img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.pdf-thumb:hover .pdf-thumb-page {
+  box-shadow: 0 0 0 1px var(--text-faint), 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+.pdf-thumb.is-current .pdf-thumb-page {
+  box-shadow: 0 0 0 2px var(--interactive-accent), 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+.pdf-thumb-label {
+  height: 22px;
+  line-height: 22px;
+  text-align: center;
+  font-size: 11px;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.pdf-thumb.is-current .pdf-thumb-label {
+  color: var(--interactive-accent);
+  font-weight: 600;
+}
+
+.pdf-viewer.has-thumbs .pdf-viewer-scroll {
+  left: var(--pdf-thumbs-width);
+}
+
+/* The annotate canvas gets its own box so the strip can narrow it; its stacking
+   context keeps tldraw's internal layers under the page box and the strip. */
+.pdf-annotate-canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.pdf-annotate-pane.has-thumbs .pdf-annotate-canvas {
+  left: var(--pdf-thumbs-width);
+}
+
+.pdf-viewer-thumbs-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 4px 6px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.pdf-viewer-thumbs-toggle:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.pdf-viewer-thumbs-toggle.is-on {
+  color: var(--interactive-accent);
+}
+
 /* tldraw's own dark canvas (hsl(240,5%,6.5%) ≈ #101011) reads as a hole next
    to the app's #202020 chrome — pin it to the app palette. Dark only: the
    light canvas already blends in. */

--- a/src/utils/helpDoc.ts
+++ b/src/utils/helpDoc.ts
@@ -243,11 +243,17 @@ intend to hand in.
 ### PDFs
 A PDF opens in a reader: scroll it, select its text, search it with \`Cmd + F\`,
 follow its links, and jump to a page with the box at the bottom. Pinch or hold
-\`Ctrl\` and scroll to zoom, or use the \`+\` and \`-\` keys.
+\`Ctrl\` and scroll to zoom, or use the \`+\` and \`-\` keys. The button beside the
+page box opens a **strip of page thumbnails** down the left; click one to go to
+that page.
 
 \`Cmd + E\` (or the pen in the top bar) switches between reading a PDF and
 **writing on it** — the same toggle every other file has. Draw on it as you would
-on a notebook.
+on a notebook. It opens **on the page you were reading**, with the same page box
+and thumbnail strip, and switching back to reading returns you to wherever you
+stopped writing. Swiping scrolls the page up and down like a PDF, and pinching
+zooms — at full width the page fills the screen edge to edge, and you can zoom in
+past that. The page can never be swiped off screen.
 
 **The marks go into that PDF, not into a copy.** There is no second
 "(annotated)" file to keep track of, and nothing to remember to open next time:

--- a/src/utils/pdfViewState.ts
+++ b/src/utils/pdfViewState.ts
@@ -1,0 +1,78 @@
+// Where a PDF was left, and whether its page strip is open — ONE record shared
+// by the reader (PdfViewer) and the annotate canvas.
+//
+// Shared because they are two views of one document: pressing annotate on page
+// 212 has to land on page 212, and leaving annotate on page 40 has to reopen the
+// reader on page 40. Each used to keep its own idea of "where", so annotate
+// opened on whatever its snapshot's camera last said — or, on a first open,
+// zoomed out to fit every page of the document at once.
+//
+// Imports nothing heavy: both the reader and the annotate chunk load it, and it
+// must not drag pdf.js or tldraw into the other.
+
+import { flushRecord, readRecord, scopedKey } from './storage';
+
+const POSITIONS_KEY = 'pdfViewPositions';
+const THUMBNAILS_KEY = 'pdfThumbnailsOpen';
+
+export interface PdfViewPos {
+    /** 0-based index of the page under the top edge of the view. */
+    page: number;
+    /** How far into that page the top edge sits, as a fraction of its height. */
+    offset: number;
+    /** Zoom on top of fit-width (1 = fit width). */
+    zoom?: number;
+}
+
+/** Where `path` was left, if anywhere. Values are the user's to edit in
+ *  localStorage, so callers still clamp `page` to the document they have. */
+export function readPdfViewPos(path: string): PdfViewPos | undefined {
+    const pos = readRecord<PdfViewPos>(POSITIONS_KEY)[scopedKey(path)];
+    if (!pos || !Number.isFinite(pos.page)) return undefined;
+    return {
+        page: Math.max(0, Math.floor(pos.page)),
+        offset: Number.isFinite(pos.offset) ? Math.min(1, Math.max(0, pos.offset)) : 0,
+        zoom: Number.isFinite(pos.zoom) ? pos.zoom : undefined,
+    };
+}
+
+/**
+ * Record where `path` is.
+ *
+ * `flush: false` updates only the in-memory record — a property write, cheap
+ * enough for every frame of a pan. That is what the annotate canvas does, and it
+ * matters: the reader reads this record WHILE RENDERING, in the very commit that
+ * unmounts the canvas, so a position that only reached memory on a debounce
+ * would reopen the reader a page or two behind. Disk can lag; memory must not.
+ */
+export function writePdfViewPos(path: string, pos: PdfViewPos, flush = true): void {
+    // The record is held parsed in memory — mutate and write, no re-parse.
+    readRecord<PdfViewPos>(POSITIONS_KEY)[scopedKey(path)] = {
+        page: pos.page,
+        offset: Math.round(pos.offset * 1000) / 1000,
+        ...(pos.zoom !== undefined ? { zoom: Math.round(pos.zoom * 1000) / 1000 } : {}),
+    };
+    if (flush) flushRecord(POSITIONS_KEY);
+}
+
+/** Write whatever `writePdfViewPos(…, false)` has accumulated. */
+export function flushPdfViewPositions(): void {
+    flushRecord(POSITIONS_KEY);
+}
+
+/** Whether the page strip is open. One app-wide preference, not per file: it
+ *  is about how you like to read, and a strip that opened on some PDFs and not
+ *  others would read as broken. A blocked localStorage just means closed. */
+export function readThumbnailsOpen(): boolean {
+    try {
+        return localStorage.getItem(THUMBNAILS_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+export function writeThumbnailsOpen(open: boolean): void {
+    try {
+        localStorage.setItem(THUMBNAILS_KEY, String(open));
+    } catch { /* the toggle still works for this session */ }
+}


### PR DESCRIPTION
## What changes for you

- **Annotate opens on the page you are reading**, at full width, instead of every page of the document at once. Switching back to reading returns you to where you stopped writing.
- **A page number box in annotate**: type a page, press Enter.
- **Page thumbnails in both the reader and annotate**, from the button beside the page box. The current page is highlighted, the strip follows as you scroll, and clicking one jumps there. Open or closed is remembered.
- **Annotate scrolls like a PDF**: two-finger swipes are vertical only, pinch zooms, full width is the page edge to edge, and the page can never be swiped off screen.

## Why it was wrong

The canvas called `zoomToFit()` on a first open and restored its snapshot's camera on a reopen, and neither knew where the reader was. Underneath, it rasterized **every** page in order before showing any: 300 renders and JPEG encodes on a 300-page book to show one page.

## Performance

- **Annotate opens faster on long PDFs.** Pages rasterize only as they come near the view, nearest first, re-deciding after each page.
- **The strip costs what is on screen.** It is windowed (11 of 40 rows in the DOM on a 40-page PDF), renders one thumbnail at a time, and caps its JPEG cache at 160.
- **Scrolling never re-renders the reader's page column.** The current page reaches the strip through an imperative handle, not a prop.
- **Drawing no longer triggers page tracking.** It moved from a session-scope store listener that fired on every pointer move to a `react()` on the viewport, which fires only when the view moves.

## Notes

- Position is one record shared by both modes (`utils/pdfViewState.ts`). The reader reads it while rendering, in the same commit that unmounts the canvas, so the canvas updates memory every frame and only debounces the write to storage.
- Branched from the rewritten `main`. Local and upstream trees were verified byte-identical at PR #5 before rebasing, and this sits cleanly on top of #13.

## Verification

Typecheck, lint and build clean. One browser pass: the reader jumps to page 25 and the strip follows; annotate opens on page 25; typing 3 jumps; sideways swipes do nothing; swiping to either end stops at pages 40 and 1; pinching out keeps the page centred.