### PR TITLE
Add a garbage bin that shows everything the vault has trashed

### DIFF
--- a/.agents/skills/vault-filesystem/SKILL.md
+++ b/.agents/skills/vault-filesystem/SKILL.md
@@ -9,6 +9,7 @@ description: How this app reads and writes the user's real files — the File Sy
 Everything else goes through `useFileSystem()`: `readFile`/`writeFile`, binary
 `readFileBytes`/`writeFileBytes`, `createFile`/`createFolder`, `moveFile`/`renameFile`/`moveToTrash`,
 `importFiles`, `getAssetUrl`/`saveAsset`/`retireAsset`/`restoreAsset`,
+`listTrash`/`restoreFromTrash`/`deleteFromTrash`/`emptyTrash`,
 `pickDirectory`/`restoreVault`/`openRecentVault`/`openFolderAsVault`.
 
 There is no backend and no undo stack behind these calls — a mistake here destroys the user's notes.
@@ -66,6 +67,59 @@ existed.
    pseudo-path is a bare name, so a vault folder called `help-guide` closed the Help tab. Left open,
    those tabs draw notes that no longer exist, hold handles that resolve to nothing, and are written
    straight back into the stored session.
+
+## The Trash bin (`listTrash` + `utils/trash.ts` + `components/TrashPanel.tsx`)
+
+The sidebar's bin icon (right-hand end of the Settings row) opens a modal listing everything trashed
+anywhere in the open vault. **`walkForTrash` and the four mutually-recursive collectors under it
+(`collectGarbage`, `buildTrashedDir`, `collectRetired`, `measureLiveAssets`) in
+`FileSystemContext.tsx` are the only code in the app that walks INTO a `.Garbage`** — `buildFileTree`
+hides them and nothing else looks.
+
+- **The crawl is DELIBERATELY UNCACHED**, a stated exception to AGENTS.md's whole-vault-walk rule. It
+  runs on a click and never on a save, so the `(lastModified, size)` cache `graph.ts`/`vaultSearch.ts`
+  need would only be a second vault-sized index in a tab that already holds one. It must **never
+  subscribe to `saveEpoch`**, holds metadata only (name, size, mtime — never a file's bytes), and the
+  panel re-crawls on every open and after nothing else. An unreadable folder is logged and skipped:
+  one locked directory must not cost the reader the rest of their trash.
+- **THE ONE RULE: an item belongs to the parent of the OUTERMOST `.Garbage` on its path** — the crawl
+  carries it down as `ownerDir`/`ownerPath` from the first `.Garbage` it enters and never recomputes
+  it, which is the whole of the definition. That is what makes a deeply nested child restore
+  **flat**, beside that `.Garbage`, instead of under a recreation of an ancestry the user no longer
+  has. There is deliberately nothing persisted about where anything came from — a `.Garbage` sits
+  beside what it holds, so the answer is derivable from the path at any "tier" of vault.
+- **The four listing rules**, applied at every depth: a file or a non-dot folder directly in
+  `F/.Garbage` is a root row (a folder being drillable); `F/.Garbage/.Assets/*` are **retired**
+  pictures, listed individually and restored into `F/.Assets` (an embed resolves from nowhere else);
+  `F/.Garbage/homework/.Assets` is that folder's **live** pictures — **never listed**, they travel
+  back with it, and count only towards its size; and anything inside a **nested** `.Garbage`
+  (`F/.Garbage/homework/.Garbage/old.md`) is **hoisted to the bin root** with destination `F/`,
+  because it was deleted from `homework` *before* `homework` was and was never part of that deletion.
+- **Put-back never goes through `moveFile`/`renameFile`** — they are the documented `freeEntryName`
+  exceptions, so a colliding file would be silently truncated and a colliding folder silently merged,
+  neither with a rollback. `restoreFromTrash` mirrors `moveToTrash` instead: mode `'auto'` reports
+  `'collision'` with **nothing touched**, and App answers it with the app's only three-way question
+  (`askChoice` → `ConfirmDialog`'s optional `altLabel`/`onAlt`).
+- **"Replace" DISPLACES, it does not erase**: the live entry is moved into that folder's own
+  `.Garbage` (a picture into its `.Garbage/.Assets`, which is where a retired picture lives) and
+  handed back as `displaced` so the bin lists it. `deleteFromTrash`/`emptyTrash` are the only two
+  calls in the app that destroy something the user made with no copy surviving.
+- **`displaceInto(bucket, dir, entry)` is shared with `moveToTrash`** and owns the
+  record-before-the-first-byte rollback documented below. Change it and you change both.
+- **The three MUTATING bin handlers take `App`'s existing `trashInFlightRef`** (the one `handleTrash`
+  uses) and drain `reconcileQueueRef.current` before each write — they are copy-then-delete over the
+  same vault. The crawl and the preview reads take neither: they are read-only. Only one dialog fits
+  on screen, so `ask`/`askChoice`/`tell` all go through `raise`, which settles the question it
+  displaces as a cancel — otherwise the displaced promise never resolves and the in-flight ref its
+  caller holds stays true for the session, silently killing every later Trash operation. A 'replace'
+  also closes every tab at the displaced path **or under it**: those handles resolve to the directory
+  entry the restored copy now occupies, so one keystroke would overwrite what was just put back. The
+  panel also closes on `rootHandle` change: every row holds handles from one vault.
+- **Nothing about an item's appearance comes back** — `forgetEntry` dropped its icon/colour when it
+  was trashed, and nothing records it. Panel-side: rows compose `.tree-item` (for
+  `content-visibility`), `dropTrashSubtree` prunes a restored/erased subtree from the root list **and**
+  every `children` array (a restored folder takes its hoisted rows with it), and the preview is text
+  and images ONLY — previewing a PDF or a drawing would pull pdf.js/tldraw into the main bundle.
 
 ## Nothing overwrites an existing file by accident
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,8 @@ everything behavioural is verified by Playwright driving the app in headless Chr
   This origin holds the vault's handle with permission granted, so a hole is read/write over the whole
   vault. Do not open a third.
 - **Anything that walks the whole vault goes through a `(lastModified, size)`-validated cache**
-  (`utils/graph.ts`, `utils/vaultSearch.ts`) and holds one file's text at a time. Both run after *every*
-  save — an uncached walk is a full vault read per keystroke-triggered autosave.
+  (`utils/graph.ts`, `utils/vaultSearch.ts`) and holds one file's text at a time — both run after *every*
+  save, and an uncached walk is a full vault read per autosave. The bin's crawl is the one exception.
 - **The decoration pass runs per keystroke, per arrow key, on every open pane** — memoize on immutable
   identity or measure it; read mode stays a pure function of the document (`live-preview`).
 - **Long-running async work over the vault is serialized, never merely started** — trashing a folder,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { buildGraph, collectMarkdownFiles, baseName, clearLinkCache } from './ut
 import { readJSON, setRecordScope, writeJSON } from './utils/storage';
 import { pruneSessions, readSession, writeSession } from './utils/tabSessions';
 import { joinVaultPath, parentVaultPath } from './utils/paths';
-import { assetEmbeds, referencesAsset } from './utils/assets';
+import { ASSETS_DIR, assetEmbeds, referencesAsset } from './utils/assets';
 import { collectFiles } from './utils/tree';
 import { bumpSaveEpoch } from './utils/saveEpoch';
 import { isTextFile } from './utils/vaultSearch';
@@ -54,8 +54,9 @@ import ConfirmDialog from './components/ConfirmDialog';
 import ContextMenu from './components/ContextMenu';
 import EditorPane from './components/EditorPane';
 import SettingsPanel from './components/SettingsPanel';
+import TrashPanel from './components/TrashPanel';
 import GraphView from './components/GraphView';
-import { Settings, HelpCircle, Network, FileTextOutline, PanelLeft, Search } from './components/icons';
+import { Settings, HelpCircle, Network, FileTextOutline, PanelLeft, Search, Trash2 } from './components/icons';
 import type {
   ActiveFile,
   FileTreeNode,
@@ -70,6 +71,8 @@ import type {
   CaretStyle,
   EditorRevealRequest,
   TextRange,
+  TrashItem,
+  TrashRestoreResult,
 } from './types';
 
 /**
@@ -151,6 +154,12 @@ interface AppDialog extends DialogRequest {
   onConfirm: () => void;
   /** Absent on a notice, which has nothing to decline. */
   onCancel?: () => void;
+  /** The third answer, and its label, on the one question that has one — see
+   *  `askChoice`. Deliberately NOT on `DialogRequest`: ConfirmDialog draws the
+   *  third button only when it has both, so an `altLabel` handed to `ask` or
+   *  `tell` would type-check and then silently render nothing. */
+  altLabel?: string;
+  onAlt?: () => void;
 }
 
 /**
@@ -244,6 +253,10 @@ export default function App() {
     restoreAsset,
     restoreVault,
     moveToTrash,
+    listTrash,
+    restoreFromTrash,
+    deleteFromTrash,
+    emptyTrash,
     moveFile,
     renameFile,
   } = useFileSystem();
@@ -290,6 +303,11 @@ export default function App() {
   const [treeFontSize, setTreeFontSize] = useState<number>(() => parseInt(localStorage.getItem('treeFontSize') || '13', 10));
   const [editorPadding, setEditorPadding] = useState<number>(() => parseInt(localStorage.getItem('editorPadding') || '6', 10));
   const [showSettings, setShowSettings] = useState<boolean>(false);
+  /** Whether the Trash bin is on screen. Its rows hold handles crawled out of
+   *  ONE vault, so the panel closes when the vault does (see the effect beside
+   *  the context menu's) — a put-back clicked after a switch would otherwise
+   *  write into the vault the reader has left. */
+  const [showTrash, setShowTrash] = useState<boolean>(false);
 
   // Spaces a Tab inserts — and how far Tab indents a list item. Clamped on the
   // way in: localStorage is user-editable and a NaN would reach CodeMirror.
@@ -461,19 +479,68 @@ export default function App() {
   // that opens another one is never fighting the first for the screen.
   const [dialog, setDialog] = useState<AppDialog | null>(null);
 
+  // The one on screen, for `raise` below. A ref and not the state, because all
+  // three helpers must stay STABLE (`notify` reaches every memoized
+  // DocumentPane) and reading `dialog` would put it in their deps.
+  const dialogRef = useRef<AppDialog | null>(null);
+
+  /**
+   * Put a question on screen, settling whatever was already there.
+   *
+   * One slot holds one dialog, and each of these hands back a promise the caller
+   * is awaiting — so a second question arriving while one is up used to replace
+   * it and leave the first promise pending FOR THE SESSION. Whoever was awaiting
+   * it never reached its `finally`, so the in-flight ref it holds (`trashInFlight`
+   * covers the question as well as the copy) stayed true and every later Move to
+   * Trash and every Trash-bin operation silently did nothing. Reachable: any
+   * background job that reports through `tell` — a notebook's PDF export runs for
+   * seconds with no overlay — landing while the bin's confirmation is open.
+   *
+   * Dismissing the displaced one is the honest reading: its question was taken
+   * off the screen before it could be answered, so its caller hears "no".
+   */
+  const raise = useCallback((next: AppDialog) => {
+    // Settled FIRST, so that its own `setDialog(null)` cannot land on top of the
+    // dialog installed below — both writes batch, and the last one must win.
+    const prev = dialogRef.current;
+    if (prev) (prev.onCancel ?? prev.onConfirm)();
+    dialogRef.current = next;
+    setDialog(next);
+  }, []);
+
+  const settle = useCallback(() => { dialogRef.current = null; setDialog(null); }, []);
+
   const ask = useCallback((question: DialogRequest) => new Promise<boolean>(resolve => {
-    setDialog({
+    raise({
       ...question,
-      onConfirm: () => { setDialog(null); resolve(true); },
-      onCancel: () => { setDialog(null); resolve(false); },
+      onConfirm: () => { settle(); resolve(true); },
+      onCancel: () => { settle(); resolve(false); },
     });
-  }), []);
+  }), [raise, settle]);
+
+  /**
+   * A question with THREE answers, for the one place a yes/no cannot say what
+   * the reader means: putting something back out of the Trash onto a name that
+   * is taken is "replace it", "keep both", or "leave it where it is", and
+   * folding either of the first two into the other would decide for them.
+   * Escape and a click outside still cancel — the alternative is never a
+   * dismissal.
+   */
+  const askChoice = useCallback((question: DialogRequest & { altLabel: string }) =>
+    new Promise<'confirm' | 'alt' | 'cancel'>(resolve => {
+      raise({
+        ...question,
+        onConfirm: () => { settle(); resolve('confirm'); },
+        onAlt: () => { settle(); resolve('alt'); },
+        onCancel: () => { settle(); resolve('cancel'); },
+      });
+    }), [raise, settle]);
 
   /** Report something and wait for it to be read. One button, so Escape and a
    *  click outside mean the same as pressing it. */
   const tell = useCallback((notice: DialogRequest) => new Promise<void>(resolve => {
-    setDialog({ ...notice, onConfirm: () => { setDialog(null); resolve(); } });
-  }), []);
+    raise({ ...notice, onConfirm: () => { settle(); resolve(); } });
+  }), [raise, settle]);
 
   // ── The app's own right-click menu ──────────────────────────────────────
   // One menu is on screen at a time, and every raiser — the editor, a table
@@ -488,6 +555,12 @@ export default function App() {
   // of those go away when the workspace switches out from under them. Leaving
   // the menu on screen would leave rows that act on something unmounted.
   useEffect(() => { closeContextMenu(); }, [mainView, rootHandle]);
+
+  // Same hazard, one surface further out: every row in the Trash panel closes
+  // over a handle from the vault it was crawled in, and nothing in those
+  // handles goes stale when the vault does — a put-back clicked afterwards
+  // would copy a file into a folder of the vault the reader just left.
+  useEffect(() => { setShowTrash(false); }, [rootHandle]);
 
   /** Say something went wrong, in the app's own dialog. One button, because
    *  there is nothing to decide. STABLE — it is handed to EditorPane and on to
@@ -1906,6 +1979,235 @@ export default function App() {
     }
   }, [moveToTrash, removeTab, flushTab, ask, tell, writeEntryStyles]);
 
+  /* ── The Trash bin ──────────────────────────────────────────────────────
+   * The panel draws the list and owns nothing else: every one of these asks
+   * the question, takes the SAME in-flight ref `handleTrash` does, and drains
+   * the asset-reconcile queue first.
+   *
+   * The shared ref is deliberate. All four are copy-then-delete over the same
+   * vault, so two at once is the abandoned-half-written-copy hazard
+   * handleTrash documents — and the guard has to cover the QUESTION as well as
+   * the copy, because only one dialog fits on screen: a second `ask` raised
+   * while one is up leaves the first promise unresolved for the session.
+   * Draining `reconcileQueueRef` matters for the same reason it does there —
+   * a retire may be moving a picture between `.Assets` and `.Garbage/.Assets`
+   * at that moment, which is exactly what the bin is reading and writing.
+   * ─────────────────────────────────────────────────────────────────────── */
+
+  /** Put one trashed item back beside the `.Garbage` it was found in. */
+  const handleTrashRestore = useCallback(async (item: TrashItem): Promise<TrashRestoreResult> => {
+    if (trashInFlightRef.current) return { status: 'error' };
+    trashInFlightRef.current = true;
+    try {
+      await reconcileQueueRef.current;
+      // Where the clash actually is — a retired picture goes back INSIDE that
+      // folder's `.Assets`, so naming the folder itself would send the reader
+      // looking at the wrong one.
+      const where = item.origin === 'retired'
+        ? joinVaultPath(item.restorePath, ASSETS_DIR)
+        : (item.restorePath || 'the vault root');
+      // Which open documents a 'replace' would take with it: the entry standing
+      // at the destination name, and — when that entry is a FOLDER — every
+      // document open from inside it. Both, by one prefix test, because App
+      // cannot know which kind is in the way until the copy resolves it, and a
+      // file has no children for the `/` branch to match anyway. A retired
+      // picture's destination is `.Assets`, which nothing opens as a tab. The
+      // Help guide is excluded: its pseudo-path is a bare name (`help-guide`),
+      // so a vault folder of that name would otherwise close it.
+      const taken = item.origin === 'retired' ? null : joinVaultPath(item.restorePath, item.name);
+      const doomed = (tab: typeof tabsRef.current[number]) =>
+        !!taken && !tab.file.isHelp &&
+        (tab.file.path === taken || tab.file.path.startsWith(`${taken}/`));
+      // Asked for without permission to overwrite: a taken name comes back as
+      // a collision with nothing touched, and the reader decides.
+      let result = await restoreFromTrash(item, 'auto');
+
+      if (result.status === 'collision') {
+        const choice = await askChoice({
+          title: 'That name is taken',
+          confirmLabel: 'Replace',
+          altLabel: 'Keep both',
+          danger: true,
+          body: (
+            <>
+              {/* `where` is a real path everywhere except one case — a file
+                  trashed from the vault root — where it is prose, and prose set
+                  in monospace reads as a folder nobody has. */}
+              {item.restorePath || item.origin === 'retired' ? <code>{where}</code> : 'The vault root'}
+              {' '}already holds something called <strong>{item.name}</strong>.
+              Replacing it moves what is there now into that folder’s own <code>.Garbage</code> —
+              it will be waiting here in the Trash, not erased. Keeping both puts this one back
+              under a numbered name.
+            </>
+          ),
+        });
+        if (choice === 'cancel') return { status: 'collision' };
+
+        if (choice === 'confirm') {
+          // Write out what is still in the save debounce, so the copy that gets
+          // displaced into `.Garbage` carries the reader's last words rather
+          // than the disk's — handleTrash's reason, and its ordering.
+          await Promise.all(tabsRef.current.filter(doomed).map(t => flushTab(t.file.path)));
+          // …and re-drain the reconcile queue: the question above took real time,
+          // and a retire can have queued a picture move into the very
+          // `.Garbage/.Assets` a retired put-back is about to read.
+          await reconcileQueueRef.current;
+        }
+        result = await restoreFromTrash(item, choice === 'confirm' ? 'replace' : 'keep-both');
+        // The displaced entry's bytes have just moved into `.Garbage`, and every
+        // tab that was open from it still holds a handle resolving to that
+        // DIRECTORY ENTRY — which the restored copy now occupies. Left open,
+        // the next keystroke in one of them writes the displaced bytes straight
+        // over the note that was just put back (measured: putting a trashed
+        // `homework` back over a live one restored its `hw1.md`, and one
+        // keystroke in the still-open tab turned it back into the live file's
+        // text). releaseOverwritten's hazard exactly. Closed WITHOUT flushing —
+        // that already happened above, before the copy.
+        if (choice === 'confirm' && result.status === 'ok') {
+          for (const tab of tabsRef.current) if (doomed(tab)) removeTab(tab.file.path, false);
+          // The displaced entry's icon and colour go into the Trash with it, or
+          // the item that just took its path inherits a look nobody chose —
+          // handleTrash's reason for forgetting them at trash time.
+          if (taken) {
+            const remaining = forgetEntry(getEntryStyles(), taken);
+            if (remaining !== getEntryStyles()) void writeEntryStyles(remaining);
+          }
+        }
+      }
+
+      if (result.status === 'error') {
+        await tell({
+          title: 'Nothing was put back',
+          confirmLabel: 'OK',
+          body: (
+            <>
+              <strong>{item.name}</strong> is still in the Trash, and nothing was left half-done.
+              The details are in the browser console. Try again in a moment.
+            </>
+          ),
+        });
+        return result;
+      }
+
+      if (result.status === 'ok') {
+        // A numbered rename must never be silent — "Keep both" says there will
+        // be a number, not what it is. Re-armed over any pending "Saved", the
+        // way handleTrash re-arms it.
+        if (result.name !== item.name) {
+          if (saveStatusTimerRef.current) clearTimeout(saveStatusTimerRef.current);
+          setSaveStatus(`Put back as “${result.name}”`);
+          saveStatusTimerRef.current = setTimeout(() => setSaveStatus(''), 4000);
+        }
+      }
+      return result;
+    } finally {
+      trashInFlightRef.current = false;
+    }
+  }, [restoreFromTrash, askChoice, tell, removeTab, flushTab, writeEntryStyles]);
+
+  /** Erase one trashed item. One of the app's two points of no return. */
+  const handleTrashDelete = useCallback(async (item: TrashItem) => {
+    if (trashInFlightRef.current) return false;
+    trashInFlightRef.current = true;
+    try {
+      const confirmed = await ask({
+        title: 'Delete for good?',
+        confirmLabel: 'Delete permanently',
+        danger: true,
+        body: (
+          <>
+            <strong>{item.name}</strong>{item.kind === 'directory' ? ' and everything inside it' : ''} is
+            erased from your disk. This is one of the only two things in this app that cannot be
+            undone — there is no second copy anywhere.
+          </>
+        ),
+      });
+      if (!confirmed) return false;
+
+      await reconcileQueueRef.current;
+      const done = await deleteFromTrash(item);
+      if (!done) {
+        await tell({
+          title: 'Nothing was deleted',
+          confirmLabel: 'OK',
+          body: (
+            <>
+              <strong>{item.name}</strong> is still in the Trash. Something inside it may be in use;
+              the details are in the browser console.
+            </>
+          ),
+        });
+      }
+      return done;
+    } finally {
+      trashInFlightRef.current = false;
+    }
+  }, [ask, tell, deleteFromTrash]);
+
+  /** Erase every `.Garbage` in the vault. The other point of no return. */
+  const handleTrashEmpty = useCallback(async (count: number) => {
+    if (trashInFlightRef.current) return false;
+    trashInFlightRef.current = true;
+    try {
+      const confirmed = await ask({
+        title: 'Empty the Trash?',
+        confirmLabel: 'Empty bin',
+        danger: true,
+        body: (
+          <>
+            All {count} item{count === 1 ? '' : 's'} here are erased from your disk, and so is
+            every <code>.Garbage</code> folder in this vault — deleted notes, deleted folders, and
+            pictures your notes stopped using. There is no second copy of any of it, and nothing
+            brings it back.
+          </>
+        ),
+      });
+      if (!confirmed) return false;
+
+      await reconcileQueueRef.current;
+      const { removed, failed } = await emptyTrash();
+      if (!removed && count > 0) {
+        await tell({
+          title: 'Nothing was deleted',
+          confirmLabel: 'OK',
+          body: <>The Trash is still where it was. The details are in the browser console.</>,
+        });
+        return false;
+      }
+      // Partly done is not done, and the panel would otherwise clear its list
+      // and say the bin was empty while those folders still held their files.
+      if (failed) {
+        await tell({
+          title: 'Some of it is still there',
+          confirmLabel: 'OK',
+          body: (
+            <>
+              {failed} folder{failed === 1 ? '' : 's'} would not empty — something inside may be in
+              use. The rest is gone. Open the Trash again to see what is left; the details are in
+              the browser console.
+            </>
+          ),
+        });
+        return false;
+      }
+      return true;
+    } finally {
+      trashInFlightRef.current = false;
+    }
+  }, [ask, tell, emptyTrash]);
+
+  /** The bin's read-only preview of a trashed text file. */
+  const handleTrashReadText = useCallback(
+    (item: TrashItem) => readFile(item.handle as FileSystemFileHandle), [readFile]);
+
+  /** The bytes behind the bin's picture preview. Here rather than in the panel
+   *  so no component calls the File System Access API itself (AGENTS.md). The
+   *  cast is sound for the same reason `handleTrashReadText`'s is: the crawl only
+   *  ever hands a file handle to an item whose `kind` is 'file', and the preview
+   *  asks for nothing else. */
+  const handleTrashReadFile = useCallback(
+    (item: TrashItem) => (item.handle as FileSystemFileHandle).getFile(), []);
+
   /**
    * Follow every open document through a rename or a move.
    *
@@ -2245,14 +2547,30 @@ export default function App() {
             <HelpCircle size={16} />
             Help Guide
           </button>
-          <button
-            className="theme-toggle-btn settings-btn"
-            onClick={() => setShowSettings(true)}
-            title="Settings"
-          >
-            <Settings size={16} />
-            Settings
-          </button>
+          {/* The bin rides the Settings row rather than taking a row of its
+              own: it is the one control down here with nothing to say in words,
+              and a fifth full-width row of chrome for it would push the tree up
+              for a button most sessions never press. The three rows above are
+              deliberately untouched. */}
+          <div className="sidebar-bottom-row">
+            <button
+              className="theme-toggle-btn settings-btn"
+              onClick={() => setShowSettings(true)}
+              title="Settings"
+            >
+              <Settings size={16} />
+              Settings
+            </button>
+            <button
+              className="tree-action-btn sidebar-trash-btn"
+              onClick={() => setShowTrash(true)}
+              title="Trash — everything deleted in this vault"
+              aria-label="Trash"
+              disabled={!rootHandle}
+            >
+              <Trash2 size={16} />
+            </button>
+          </div>
         </div>
       </div>
       {!sidebarCollapsed && <div className="workspace-resize-handle" onMouseDown={startResize} />}
@@ -2325,6 +2643,20 @@ export default function App() {
           onClose={() => setShowSettings(false)}
         />
       )}
+      {/* Over the workspace like Settings, and before ConfirmDialog for the
+          same reason the menu is: nearly everything this panel does raises a
+          question, and the dialog has to cover the panel that asked it. */}
+      {showTrash && (
+        <TrashPanel
+          onClose={() => setShowTrash(false)}
+          onCrawl={listTrash}
+          onRestore={handleTrashRestore}
+          onDelete={handleTrashDelete}
+          onEmpty={handleTrashEmpty}
+          onReadText={handleTrashReadText}
+          onReadFile={handleTrashReadFile}
+        />
+      )}
       {/* Before the dialog, so ConfirmDialog still covers it: a menu row can
           raise a question (Move to Trash), and the menu closes first anyway. */}
       {contextMenu && <ContextMenu request={contextMenu} onClose={closeContextMenu} />}
@@ -2336,6 +2668,8 @@ export default function App() {
           title={dialog.title}
           confirmLabel={dialog.confirmLabel}
           danger={dialog.danger}
+          altLabel={dialog.altLabel}
+          onAlt={dialog.onAlt}
           onConfirm={dialog.onConfirm}
           onCancel={dialog.onCancel}
         >

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -35,9 +35,24 @@ interface ConfirmDialogProps {
      * same thing it does, because there is nothing else they could mean.
      */
     onCancel?: () => void;
+    /**
+     * A SECOND way of going ahead, drawn between Cancel and the confirm button,
+     * and only when `onAlt` comes with it.
+     *
+     * It exists because one question in the app genuinely has three answers: a
+     * put-back from the Trash whose name is already taken can replace what is
+     * there or keep both, and cancelling is neither. Folding that into a second
+     * hand-rolled overlay is exactly what the doc comment above says this
+     * component exists to prevent.
+     */
+    altLabel?: string;
+    /** What the third button does. Never a dismissal — Escape and the click
+     *  outside still mean `onCancel`, because backing out is what those mean
+     *  everywhere else in the app. */
+    onAlt?: () => void;
 }
 
-export default function ConfirmDialog({ title, children, confirmLabel, danger, onConfirm, onCancel }: ConfirmDialogProps) {
+export default function ConfirmDialog({ title, children, confirmLabel, danger, onConfirm, onCancel, altLabel, onAlt }: ConfirmDialogProps) {
     const titleId = useId();
     const confirmRef = useRef<HTMLButtonElement | null>(null);
 
@@ -93,6 +108,9 @@ export default function ConfirmDialog({ title, children, confirmLabel, danger, o
                 <div className="confirm-actions">
                     {onCancel && (
                         <button className="confirm-btn" onClick={onCancel}>Cancel</button>
+                    )}
+                    {altLabel && onAlt && (
+                        <button className="confirm-btn" onClick={onAlt}>{altLabel}</button>
                     )}
                     <button
                         ref={confirmRef}

--- a/src/components/TrashPanel.tsx
+++ b/src/components/TrashPanel.tsx
@@ -1,0 +1,506 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FileText, FolderIcon, RotateCcw, Trash2 } from './icons';
+import { dropTrashSubtree, formatDeletedAt, formatTrashSize } from '../utils/trash';
+import { isCanvasFile, isImageFile } from '../utils/fileTypes';
+import { isTextFile } from '../utils/vaultSearch';
+import { ASSETS_DIR } from '../utils/assets';
+import type { TrashItem, TrashRestoreResult } from '../types';
+
+/**
+ * What the right-hand pane is showing for the selected FILE. A folder never
+ * reaches this: its row is a place to go into, and what it has to say (how much
+ * is in it) is already in the item the crawl built, with nothing to read.
+ */
+type Preview =
+    | { status: 'loading' }
+    | { status: 'text'; text: string }
+    | { status: 'image'; url: string }
+    /** There is nothing to show, and `reason` is the line that says why. */
+    | { status: 'none'; reason: string }
+    | { status: 'error' };
+
+/**
+ * Text bigger than this is not previewed. The preview answers one question —
+ * "is this the `notes.md` I meant, or the other one" — and the first screen
+ * answers it; a 2MB file read and laid out as one <pre> buys nothing for the
+ * pause it costs on a click that might have been a mis-click.
+ */
+const MAX_PREVIEW_BYTES = 2 * 1024 * 1024;
+
+/** Keyboard activation (Enter/Space) for the clickable rows. SearchPanel's, by
+ *  copy: a `.tsx` may only export components (react-refresh), so sharing it
+ *  would mean a module for four lines that neither panel would import twice.
+ *
+ *  With one line its rows do not need: these carry Put back and Delete BUTTONS
+ *  inside the row, and Enter on a button bubbles up here — where preventDefault
+ *  would cancel the button's own activation and select the row instead. */
+function rowKeyHandler(activate: () => void) {
+    return (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            activate();
+        }
+    };
+}
+
+/** The row with this `sourcePath` in the list as it is NOW, at any depth. The
+ *  crawl's paths are unique across the vault, so a path IS the identity — which
+ *  the captured objects held in `trail`/`selected` stop being the moment
+ *  `dropTrashSubtree` rebuilds an ancestor around a row that has left. */
+function findInTrash(items: TrashItem[], sourcePath: string): TrashItem | null {
+    for (const item of items) {
+        if (item.sourcePath === sourcePath) return item;
+        if (item.children) {
+            const hit = findInTrash(item.children, sourcePath);
+            if (hit) return hit;
+        }
+    }
+    return null;
+}
+
+/** Is `path` the subtree rooted at `root`, or inside it? The `path/` rule the
+ *  tab handlers and `dropTrashSubtree` use, for the same reason: `notes` must
+ *  not match `notesolder`. */
+function isWithin(path: string, root: string): boolean {
+    return path === root || path.startsWith(`${root}/`);
+}
+
+/** Where the row came from, and so where Put back will send it: the folder
+ *  holding the `.Garbage` it was found in. A retired image goes back INSIDE
+ *  that folder's `.Assets` rather than beside it — an embed resolves from
+ *  nowhere else — so the row says so, through the one module that owns that
+ *  name (utils/assets.ts) rather than spelling it a second time. */
+function restoreLabel(item: TrashItem): string {
+    if (item.origin === 'retired') {
+        return item.restorePath ? `${item.restorePath}/${ASSETS_DIR}` : ASSETS_DIR;
+    }
+    return item.restorePath || 'the vault root';
+}
+
+interface TrashPanelProps {
+    onClose: () => void;
+    /** The crawl. Called once on mount; never re-run automatically. */
+    onCrawl: () => Promise<TrashItem[]>;
+    /** Put one item back. Already includes App's confirmations and its
+     *  in-flight guard — the panel only reacts to the outcome. */
+    onRestore: (item: TrashItem) => Promise<TrashRestoreResult>;
+    /** Erase one item for good; false if nothing happened. */
+    onDelete: (item: TrashItem) => Promise<boolean>;
+    /** Erase every .Garbage in the vault; false if nothing happened. */
+    onEmpty: (count: number) => Promise<boolean>;
+    /** Read a trashed text file (CRLF-normalized) for the preview. */
+    onReadText: (item: TrashItem) => Promise<string>;
+    /** The bytes of a trashed picture, for the preview's object URL. A prop for
+     *  the same reason `onReadText` is one: the File System Access API is not a
+     *  component's to call (AGENTS.md's layering), and this is the only other
+     *  thing in here that reads a file. */
+    onReadFile: (item: TrashItem) => Promise<File>;
+}
+
+/**
+ * TrashPanel — everything in every folder's `.Garbage`, in one modal: a flat
+ * list on the left, a read-only preview on the right, and a put-back or a
+ * permanent delete on each row.
+ *
+ * The list is FLAT on purpose. The vault's own shape is the file tree's job;
+ * what the bin is for is "I deleted something, give it back", and that reads as
+ * a single newest-first list no matter which folder the deletion happened in.
+ * The one exception is a trashed folder, which stays one row you can go into —
+ * it was deleted as a unit and is put back as one.
+ *
+ * Every question this panel raises is App's (it owns `ask`/`tell` and the app's
+ * ConfirmDialog), so `onRestore`/`onDelete`/`onEmpty` have already asked by the
+ * time they resolve. The panel draws no dialogs of its own.
+ */
+export default function TrashPanel({ onClose, onCrawl, onRestore, onDelete, onEmpty, onReadText, onReadFile }: TrashPanelProps) {
+    const panelRef = useRef<HTMLDivElement | null>(null);
+    /** null while the crawl is still walking the vault. */
+    const [items, setItems] = useState<TrashItem[] | null>(null);
+    /** The folders gone into, outermost first. Empty = the bin's root list. */
+    const [trail, setTrail] = useState<TrashItem[]>([]);
+    const [selected, setSelected] = useState<TrashItem | null>(null);
+    const [preview, setPreview] = useState<Preview>({ status: 'none', reason: '' });
+    const [busy, setBusy] = useState(false);
+
+    // Whatever raised the panel — the sidebar's bin button. Read during the
+    // first render, BEFORE the effect below moves focus into the panel, so it
+    // is the opener and not the panel itself. ConfirmDialog's trick, for the
+    // same reason: a keyboard user closing this must not be dropped at the top
+    // of the document.
+    const [opener] = useState<HTMLElement | null>(() => document.activeElement as HTMLElement | null);
+
+    useEffect(() => {
+        panelRef.current?.focus();
+        return () => { if (opener?.isConnected) opener.focus(); };
+    }, [opener]);
+
+    // Take the keyboard back whenever it has fallen on the floor.
+    //
+    // Nearly everything in this panel UNMOUNTS the element that was clicked:
+    // going into a folder replaces the row that was clicked to get there, a
+    // breadcrumb step becomes plain text once it is the last one, and a put-back
+    // or a delete removes the row whose button was pressed. Chromium answers each
+    // of those by focusing <body> — and Escape is handled on the panel (see
+    // handleKeyDown), so from that moment the panel could not be closed by
+    // keyboard at all until something inside it was clicked again. Measured: open
+    // the bin, click a trashed folder, press Escape — nothing happened.
+    //
+    // Runs after EVERY commit, because every one of those paths is a state change
+    // and there is no single place to hook. Guarded on <body> exactly rather than
+    // on "outside the panel": a ConfirmDialog this panel raised holds real focus
+    // on its own button, and stealing that back would break the question's own
+    // keyboard handling.
+    useEffect(() => {
+        const active = document.activeElement;
+        if (!active || active === document.body) panelRef.current?.focus();
+    });
+
+    // Called once, and only the value it had at mount is ever used — the prop's
+    // own contract.
+    const onCrawlRef = useRef(onCrawl);
+    const crawlRef = useRef<Promise<TrashItem[]> | null>(null);
+    useEffect(() => {
+        let live = true;
+        // The crawl opens every folder in the vault looking for `.Garbage`, so
+        // it is exactly the long vault walk AGENTS.md says must be serialized
+        // rather than merely started: StrictMode's simulated remount would
+        // otherwise lay a second full walk over the first. Held as the PROMISE
+        // and not as its result — a panel that is closed and reopened is a new
+        // component, and re-crawling on every open is the product decision (the
+        // bin is never cached, because the disk is the truth).
+        const crawl = crawlRef.current ?? (crawlRef.current = onCrawlRef.current());
+        crawl.then(
+            found => { if (live) setItems(found); },
+            // App has already told the user. An empty list is still the honest
+            // end state: leaving `items` null strands the panel on "Looking
+            // through the vault…" with no way out except closing it.
+            () => { if (live) setItems([]); },
+        );
+        return () => { live = false; };
+    }, []);
+
+    // Read through refs so a fresh closure from App cannot re-trigger the
+    // effect below — that would re-read the file (or re-mint an object URL) on
+    // a render that changed nothing about what is selected.
+    const onReadTextRef = useRef(onReadText);
+    const onReadFileRef = useRef(onReadFile);
+    useEffect(() => {
+        onReadTextRef.current = onReadText;
+        onReadFileRef.current = onReadFile;
+    });
+
+    // A read is async and the pointer is not: a slow read of a big note must
+    // not land on top of the picture clicked after it. The generation ref is
+    // also what makes the object URL safe to revoke in the cleanup — a run that
+    // has been superseded returns before it ever mints one.
+    const previewSeqRef = useRef(0);
+    useEffect(() => {
+        const seq = ++previewSeqRef.current;
+        const item = selected;
+        if (!item || item.kind === 'directory') {
+            setPreview({ status: 'none', reason: '' });
+            return;
+        }
+        if (isImageFile(item.name)) {
+            let url: string | null = null;
+            setPreview({ status: 'loading' });
+            void onReadFileRef.current(item).then(
+                file => {
+                    if (seq !== previewSeqRef.current) return;
+                    url = URL.createObjectURL(file);
+                    setPreview({ status: 'image', url });
+                },
+                () => { if (seq === previewSeqRef.current) setPreview({ status: 'error' }); },
+            );
+            // Nothing else releases these, and the bin is a panel people click
+            // through dozens of rows in: without this, one decoded image stays
+            // pinned in memory per click until the tab is closed.
+            return () => { if (url) URL.revokeObjectURL(url); };
+        }
+
+        if (isTextFile(item.name) && !isCanvasFile(item.name)) {
+            if (item.size > MAX_PREVIEW_BYTES) {
+                setPreview({ status: 'none', reason: 'Too large to preview.' });
+                return;
+            }
+            setPreview({ status: 'loading' });
+            void onReadTextRef.current(item).then(
+                text => { if (seq === previewSeqRef.current) setPreview({ status: 'text', text }); },
+                () => { if (seq === previewSeqRef.current) setPreview({ status: 'error' }); },
+            );
+            return;
+        }
+
+        // PDFs, `.tldraw` and `.notebook` are the kinds it hurts most to say no
+        // to — and they are the reason it says no. Drawing any of them needs
+        // pdf.js or tldraw, and this panel is in the main bundle: one import
+        // here would put ~450kB / ~1.7MB behind the sidebar's bin button for
+        // every vault that has never held one (components/prefetchPanes.ts).
+        setPreview({ status: 'none', reason: 'No preview for this kind of file.' });
+    }, [selected]);
+
+    /**
+     * Take an item that has left the bin out of the list, along with everything
+     * under it — and, for a put-back that replaced something, put the entry it
+     * displaced at the top.
+     *
+     * Deliberately NOT a re-crawl. Walking every `.Garbage` in the vault again
+     * to learn that one row has gone would cost what opening the panel cost,
+     * and would reset the list under someone working through it row by row.
+     * utils/trash.ts holds the rules the crawl builds its answers by precisely
+     * so the list can be kept honest here without re-reading the disk.
+     */
+    const forget = useCallback((item: TrashItem, displaced?: TrashItem) => {
+        setItems(prev => {
+            if (!prev) return prev;
+            const next = dropTrashSubtree(prev, item.sourcePath);
+            // The displaced entry was a live file a moment ago: it is the
+            // newest thing in the bin, and the only row here nobody asked to
+            // delete — so it goes where it will actually be noticed.
+            return displaced ? [displaced, ...next] : next;
+        });
+        // Standing inside a folder that has just been put back or erased: step
+        // out to where it used to be rather than showing its ghost.
+        setTrail(prev => {
+            const gone = prev.findIndex(step => isWithin(step.sourcePath, item.sourcePath));
+            return gone === -1 ? prev : prev.slice(0, gone);
+        });
+        setSelected(prev => (prev && isWithin(prev.sourcePath, item.sourcePath) ? null : prev));
+    }, []);
+
+    // One bin operation at a time, gated on the REF and not on `busy`: the
+    // disabled attribute only lands on the next render, and these are slow
+    // enough (a folder is copied entry by entry) for a second click to arrive
+    // first. AGENTS.md's rule for every long vault write.
+    const busyRef = useRef(false);
+    const runExclusive = useCallback(async (work: () => Promise<void>) => {
+        if (busyRef.current) return;
+        busyRef.current = true;
+        setBusy(true);
+        try {
+            await work();
+        } catch {
+            // App owns telling the user what went wrong; all the panel owes the
+            // reader is not staying stuck in its busy state.
+        } finally {
+            busyRef.current = false;
+            setBusy(false);
+            // Focus recovery is the effect above, not here: `forget`'s setItems
+            // has not been committed at this point, so the row whose button was
+            // pressed is still mounted and still focused — a check here would
+            // see nothing wrong and skip, and the row would unmount a moment
+            // later taking the keyboard with it.
+        }
+    }, []);
+
+    const putBack = useCallback((item: TrashItem) => void runExclusive(async () => {
+        const result = await onRestore(item);
+        // 'collision' is the user answering "cancel" to the three-way name
+        // question, and 'error' is a failure App has said its piece about —
+        // except one: App returns 'error' silently when its own trash in-flight
+        // ref is held, which a reader can reach by closing this panel mid
+        // put-back and reopening it. Both statuses mean the disk is untouched,
+        // so the list must be too.
+        if (result.status === 'ok') forget(item, result.displaced);
+    }), [runExclusive, onRestore, forget]);
+
+    const erase = useCallback((item: TrashItem) => void runExclusive(async () => {
+        if (await onDelete(item)) forget(item);
+    }), [runExclusive, onDelete, forget]);
+
+    const emptyBin = useCallback(() => void runExclusive(async () => {
+        if (!items?.length) return;
+        if (!(await onEmpty(items.length))) return;
+        setItems([]);
+        setTrail([]);
+        setSelected(null);
+    }), [runExclusive, onEmpty, items]);
+
+    const openItem = useCallback((item: TrashItem) => {
+        setSelected(item);
+        // In the SAME batch as the selection, so the commit that puts this
+        // item's name in the preview's heading does not still be showing the
+        // last one's body underneath it. The effect below cannot do it: it runs
+        // after that commit has already had its chance to paint. Folders never
+        // read `preview`, so this is invisible for them.
+        if (item.kind === 'file') setPreview({ status: 'loading' });
+        // A folder is a place rather than a document, so clicking it goes in.
+        // It stays the selection as well, so the preview can say how much of
+        // the vault that one row is holding.
+        if (item.kind === 'directory') setTrail(prev => [...prev, item]);
+    }, []);
+
+    // `trail` and `selected` hold the items AS THEY WERE when they were
+    // clicked. `dropTrashSubtree` rebuilds every ancestor of a row it removes
+    // ({ ...item, children }), so a captured folder goes on serving a child
+    // that has already left the bin — re-resolve both by path against the list
+    // as it is now. A trail step that is gone entirely ends the trail.
+    const trailNow = useMemo(() => {
+        const live: TrashItem[] = [];
+        for (const step of trail) {
+            const found = items && findInTrash(items, step.sourcePath);
+            if (!found) break;
+            live.push(found);
+        }
+        return live;
+    }, [items, trail]);
+    const selectedNow = useMemo(
+        () => (selected && items ? (findInTrash(items, selected.sourcePath) ?? selected) : selected),
+        [items, selected],
+    );
+
+    const openFolder = trailNow.length ? trailNow[trailNow.length - 1] : null;
+    const rows = openFolder ? (openFolder.children ?? []) : (items ?? []);
+
+    // On the panel and NOT on `window`, which is the whole point: a window
+    // listener added at mount would be registered BEFORE the one ConfirmDialog
+    // adds when Delete permanently or Empty bin raises its question — and being
+    // first, it would fire first and close the bin out from under the dialog
+    // still asking about it. Here, an open ConfirmDialog's capture-phase
+    // listener stops Escape before React ever dispatches it to this handler,
+    // which is exactly the order the panel wants.
+    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key !== 'Escape') return;
+        e.preventDefault();
+        onClose();
+    }, [onClose]);
+
+    const renderRow = (item: TrashItem) => {
+        const activate = () => openItem(item);
+        const isSelected = selectedNow?.sourcePath === item.sourcePath;
+        return (
+            <div
+                key={item.id}
+                className={`tree-item trash-row${isSelected ? ' is-selected' : ''}`}
+                role="button"
+                tabIndex={0}
+                title={item.sourcePath}
+                onClick={activate}
+                onKeyDown={rowKeyHandler(activate)}
+            >
+                <span className={`tree-item-icon ${item.kind === 'directory' ? 'folder-icon' : 'file-icon'}`}>
+                    {item.kind === 'directory' ? <FolderIcon size={14} /> : <FileText size={14} />}
+                </span>
+                <span className="trash-row-name">{item.name}</span>
+                <span className="trash-row-dir">{restoreLabel(item)}</span>
+                <span className="trash-row-time">{formatDeletedAt(item.deletedAt)}</span>
+                <span className="tree-item-actions">
+                    <button
+                        className="tree-action-btn"
+                        title="Put back"
+                        disabled={busy}
+                        onClick={(e) => { e.stopPropagation(); putBack(item); }}
+                    >
+                        <RotateCcw size={13} />
+                    </button>
+                    <button
+                        className="tree-action-btn trash-btn"
+                        title="Delete permanently"
+                        disabled={busy}
+                        onClick={(e) => { e.stopPropagation(); erase(item); }}
+                    >
+                        <Trash2 size={13} />
+                    </button>
+                </span>
+            </div>
+        );
+    };
+
+    const renderPreview = () => {
+        if (!selectedNow) {
+            return <p className="trash-preview-empty">Pick something on the left to see what it was.</p>;
+        }
+        if (selectedNow.kind === 'directory') {
+            const count = selectedNow.children?.length ?? 0;
+            return (
+                <>
+                    <p className="trash-preview-title">{selectedNow.name}</p>
+                    <p className="trash-preview-empty">
+                        {count} item{count === 1 ? '' : 's'} inside · {formatTrashSize(selectedNow.size)}
+                    </p>
+                </>
+            );
+        }
+        const when = formatDeletedAt(selectedNow.deletedAt);
+        const size = formatTrashSize(selectedNow.size);
+        return (
+            <>
+                <p className="trash-preview-title">{selectedNow.name}</p>
+                {preview.status === 'loading' && <p className="trash-preview-empty">Reading…</p>}
+                {preview.status === 'error' && <p className="trash-preview-empty">This one could not be read.</p>}
+                {preview.status === 'image' && (
+                    <img className="trash-preview-image" src={preview.url} alt={selectedNow.name} />
+                )}
+                {preview.status === 'text' && <pre className="trash-preview-text">{preview.text}</pre>}
+                {preview.status === 'none' && (
+                    <>
+                        <p className="trash-preview-empty">{preview.reason}</p>
+                        <p className="trash-preview-empty">{when ? `${size} · deleted ${when}` : size}</p>
+                    </>
+                )}
+            </>
+        );
+    };
+
+    return (
+        <div className="trash-overlay" onMouseDown={onClose}>
+            <div
+                className="trash-panel"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Trash"
+                tabIndex={-1}
+                ref={panelRef}
+                onMouseDown={(e) => e.stopPropagation()}
+                onKeyDown={handleKeyDown}
+            >
+                <div className="trash-header">
+                    <h3 className="trash-title">Trash</h3>
+                    <button className="settings-close-btn" onClick={onClose} title="Close" aria-label="Close">×</button>
+                </div>
+                <div className="trash-body">
+                    <div className="trash-list-pane">
+                        {trailNow.length > 0 && (
+                            <div className="trash-breadcrumb">
+                                <button className="trash-crumb" onClick={() => setTrail([])}>All trash</button>
+                                {trailNow.map((step, i) => (
+                                    <React.Fragment key={step.id}>
+                                        {' / '}
+                                        {i === trailNow.length - 1 ? step.name : (
+                                            <button
+                                                className="trash-crumb"
+                                                onClick={() => setTrail(trailNow.slice(0, i + 1))}
+                                            >
+                                                {step.name}
+                                            </button>
+                                        )}
+                                    </React.Fragment>
+                                ))}
+                            </div>
+                        )}
+                        <div className="trash-list">
+                            {items === null && <p className="trash-empty">Looking through the vault…</p>}
+                            {items !== null && rows.length === 0 && (
+                                <p className="trash-empty">
+                                    {openFolder ? 'This folder was empty.' : 'Nothing has been deleted in this vault.'}
+                                </p>
+                            )}
+                            {rows.map(renderRow)}
+                        </div>
+                    </div>
+                    <div className="trash-preview-pane">{renderPreview()}</div>
+                </div>
+                <div className="trash-footer">
+                    <button
+                        className="trash-empty-btn"
+                        disabled={busy || !items?.length}
+                        onClick={emptyBin}
+                    >
+                        Empty bin
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -131,6 +131,16 @@ export function Trash2({ size = 16, className = "", ...props }: IconProps) {
     );
 }
 
+/** An arrow curling back to where it started — "put this back where it was". */
+export function RotateCcw({ size = 16, ...props }: IconProps) {
+    return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M3 2v6h6" />
+            <path d="M3.51 15a9 9 0 1 0 2.13-9.36L3 8" />
+        </svg>
+    );
+}
+
 export function Settings({ size = 16, ...props }: IconProps) {
     return (
         <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>

--- a/src/context/FileSystemContext.tsx
+++ b/src/context/FileSystemContext.tsx
@@ -6,7 +6,11 @@ import { findLinkedVault, readLocation } from '../utils/appUrl';
 import { ENTRY_STYLE_FILE, LEGACY_STYLE_FILE } from '../utils/entryStyle';
 import { ASSETS_DIR, TRASH_DIR, isAssetName } from '../utils/assets';
 import { joinVaultPath } from '../utils/paths';
-import type { FileTreeNode, FileSystemContextValue, RecentVault, StoredVault, VaultOpenResult } from '../types';
+import { sortTrashChildren, sortTrashRoot } from '../utils/trash';
+import type {
+    FileTreeNode, FileSystemContextValue, RecentVault, StoredVault, VaultOpenResult,
+    TrashItem, TrashRestoreMode, TrashRestoreResult,
+} from '../types';
 
 const FileSystemContext = createContext<FileSystemContextValue | null>(null);
 
@@ -24,6 +28,23 @@ async function entryExists(dir: FileSystemDirectoryHandle, name: string): Promis
     try { await dir.getFileHandle(name); return true; } catch { /* not a file here */ }
     try { await dir.getDirectoryHandle(name); return true; } catch { /* nor a directory */ }
     return false;
+}
+
+/**
+ * WHAT `name` is in `dir` — its kind and its handle — or null if it is nothing.
+ *
+ * `entryExists` answers whether, not which, and the two calls that displace an
+ * entry standing in a put-back's way need both: the kind decides whether the
+ * copy is recursive, and getting it wrong means a `removeEntry` that throws
+ * and a duplicate left behind.
+ */
+async function liveEntry(
+    dir: FileSystemDirectoryHandle,
+    name: string,
+): Promise<{ name: string; kind: 'file' | 'directory'; handle: FileSystemFileHandle | FileSystemDirectoryHandle } | null> {
+    try { return { name, kind: 'directory', handle: await dir.getDirectoryHandle(name) }; } catch { /* not a directory */ }
+    try { return { name, kind: 'file', handle: await dir.getFileHandle(name) }; } catch { /* nor a file */ }
+    return null;
 }
 
 /**
@@ -102,6 +123,67 @@ async function copyDirRecursive(srcDir: FileSystemDirectoryHandle, destDir: File
 }
 
 /**
+ * Move `entry` out of `dir` and into `bucket` — a `.Garbage`, or the
+ * `.Garbage/.Assets` retired pictures are parked in — under a name free there.
+ * Returns the name it was filed under.
+ *
+ * IT EITHER HAPPENED OR IT DIDN'T. Anything that throws — a copy that dies
+ * partway, or a `removeEntry` refused because a file inside is still being
+ * written — takes the copy back out again before rethrowing. Without that, the
+ * realistic failure (the copy SUCCEEDS and the removal is refused) left a
+ * complete second copy of the folder in `.Garbage`, and every retry added
+ * another numbered one: megabytes to gigabytes of trash indexed under names
+ * indistinguishable, in Finder, from a good backup. Removing it is safe
+ * precisely because it is ours — `freeEntryName` certified the name free a
+ * moment earlier and nothing else may be copying at the same time (App
+ * serializes every one of these through one in-flight ref) — so this can only
+ * unmake what it just made. It is not a licence to prune `.Garbage`, which
+ * nothing here does.
+ *
+ * Shared by `moveToTrash` and by the bin's "Replace", which displaces the live
+ * entry a put-back would land on instead of overwriting it: one rollback,
+ * written once, for both.
+ */
+async function displaceInto(
+    bucket: FileSystemDirectoryHandle,
+    dir: FileSystemDirectoryHandle,
+    entry: { name: string; kind: 'file' | 'directory'; handle: FileSystemFileHandle | FileSystemDirectoryHandle },
+): Promise<string> {
+    // What this call has written, so a failure can take it back out. Recorded
+    // before a single byte, so a copy that dies on its first file is unmade
+    // just as surely as one that dies on its last.
+    let wrote: { dir: FileSystemDirectoryHandle; name: string } | null = null;
+    try {
+        // Deleting the same name twice must not destroy the first copy.
+        const name = await freeEntryName(bucket, entry.name, entry.kind);
+        wrote = { dir: bucket, name };
+
+        if (entry.kind === 'file') {
+            await copyFileInto(bucket, name, await (entry.handle as FileSystemFileHandle).getFile());
+        } else {
+            const grave = await bucket.getDirectoryHandle(name, { create: true });
+            await copyDirRecursive(entry.handle as FileSystemDirectoryHandle, grave);
+        }
+
+        // Remove the original. Recursively for a folder — it still holds
+        // everything that was just copied out of it.
+        await dir.removeEntry(entry.name, { recursive: entry.kind === 'directory' });
+        return name;
+    } catch (err) {
+        if (wrote) {
+            try {
+                await wrote.dir.removeEntry(wrote.name, { recursive: entry.kind === 'directory' });
+            } catch (undoErr) {
+                // Nothing is lost — the original is still there — so say so and
+                // leave it rather than trying harder at a failing disk.
+                console.error('Could not remove the abandoned copy:', undoErr);
+            }
+        }
+        throw err;
+    }
+}
+
+/**
  * Recursively traverses a FileSystemDirectoryHandle and returns a nested tree.
  */
 async function buildFileTree(dirHandle: FileSystemDirectoryHandle, path = ''): Promise<FileTreeNode[]> {
@@ -150,6 +232,267 @@ async function buildFileTree(dirHandle: FileSystemDirectoryHandle, path = ''): P
     });
 
     return children;
+}
+
+/* ── The trash bin's crawl ───────────────────────────────────────────────────
+ * Everything trashed anywhere in the vault, gathered into ONE flat list, on
+ * demand. A deletion leaves no record but the copy itself sitting in the
+ * `.Garbage` beside where it came from, so finding them all means walking the
+ * whole vault — and this is the only place in the app that walks INTO those
+ * folders (buildFileTree hides them, and nothing else looks).
+ *
+ * DELIBERATELY UNCACHED, unlike the other two whole-vault walks
+ * (utils/graph.ts, utils/vaultSearch.ts, both `(lastModified, size)`-validated
+ * per AGENTS.md): those run after EVERY save, where an uncached walk would be a
+ * full vault read per keystroke-triggered autosave. This one runs when the
+ * reader clicks the bin and at no other time — it must not subscribe to
+ * `saveEpoch` — and the wait was chosen over a second vault-sized index in a
+ * tab that already holds one. It reads metadata only: a name, a size and an
+ * mtime per entry, never a file's bytes.
+ *
+ * THE ONE RULE, applied at every depth: an item belongs to the parent of the
+ * OUTERMOST `.Garbage` on its path — carried down these functions as
+ * `ownerDir`/`ownerPath` from the first `.Garbage` entered and never
+ * recomputed, which is the whole of the definition. A trashed folder keeps its own
+ * `.Garbage` inside it, so `math/.Garbage/homework/.Garbage/old.md` is a real
+ * path and means "old.md was deleted from homework, and then homework itself
+ * was deleted". It is listed at the bin's ROOT and goes back to `math/`, flat —
+ * never into a recreated `homework`, which is not a folder the reader has.
+ *
+ * A directory that cannot be read is logged and skipped rather than thrown
+ * from: one locked folder must not cost the reader the rest of their trash.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/** A file's metadata, tolerant of a read that fails mid-crawl — a file being
+ *  written as the walk passes it must not take the whole bin down. */
+async function statFile(handle: FileSystemFileHandle): Promise<{ mtime: number; size: number }> {
+    try {
+        const file = await handle.getFile();
+        return { mtime: file.lastModified, size: file.size };
+    } catch {
+        return { mtime: 0, size: 0 };
+    }
+}
+
+/** Retired pictures — `<owner>/.Garbage/.Assets/*`, parked there by retireAsset
+ *  when the last note stopped embedding them. Listed one by one rather than as
+ *  a folder (that folder is the app's bookkeeping, not something the reader
+ *  deleted), and each goes back into `<owner>/.Assets`: an embed resolves from
+ *  nowhere else, so a picture put back beside the notes would be one nothing
+ *  could display. */
+async function collectRetired(
+    assetsDir: FileSystemDirectoryHandle,
+    assetsPath: string,
+    ownerDir: FileSystemDirectoryHandle,
+    ownerPath: string,
+    out: TrashItem[],
+): Promise<void> {
+    try {
+        for await (const [name, handle] of assetsDir.entries()) {
+            if (handle.kind !== 'file' || name === '.DS_Store' || !isAssetName(name)) continue;
+            const { mtime, size } = await statFile(handle);
+            const sourcePath = joinVaultPath(assetsPath, name);
+            out.push({
+                id: sourcePath, name, kind: 'file', origin: 'retired', sourcePath,
+                handle, parentHandle: assetsDir,
+                restorePath: ownerPath, restoreDirHandle: ownerDir,
+                deletedAt: mtime, size,
+            });
+        }
+    } catch (err) {
+        console.warn('Could not read the retired pictures in', assetsPath, err);
+    }
+}
+
+/** Everything one `.Garbage` holds, as rows of the bin's root list. */
+async function collectGarbage(
+    garbageDir: FileSystemDirectoryHandle,
+    garbagePath: string,
+    ownerDir: FileSystemDirectoryHandle,
+    ownerPath: string,
+    out: TrashItem[],
+): Promise<void> {
+    try {
+        for await (const [name, handle] of garbageDir.entries()) {
+            if (name === '.DS_Store' || !isAssetName(name)) continue;
+            const sourcePath = joinVaultPath(garbagePath, name);
+
+            if (handle.kind === 'directory') {
+                if (name === ASSETS_DIR) {
+                    await collectRetired(handle, sourcePath, ownerDir, ownerPath, out);
+                    continue;
+                }
+                // A `.Garbage` directly inside a `.Garbage` is unreachable today
+                // — moveToTrash refuses to trash either hidden folder — so this
+                // is defensive. Treated as more of the same bucket rather than
+                // as a folder somebody deleted, because drawing it as one would
+                // invite a put-back that recreated a `.Garbage` in the vault.
+                if (name === TRASH_DIR) {
+                    await collectGarbage(handle, sourcePath, ownerDir, ownerPath, out);
+                    continue;
+                }
+                out.push(await buildTrashedDir(handle, sourcePath, garbageDir, ownerDir, ownerPath, out));
+                continue;
+            }
+
+            const { mtime, size } = await statFile(handle);
+            out.push({
+                id: sourcePath, name, kind: 'file', origin: 'trashed', sourcePath,
+                handle, parentHandle: garbageDir,
+                restorePath: ownerPath, restoreDirHandle: ownerDir,
+                deletedAt: mtime, size,
+            });
+        }
+    } catch (err) {
+        console.warn('Could not read the trash at', garbagePath, err);
+    }
+}
+
+/** What a trashed folder's own `.Assets` adds to its weight and its age. Not
+ *  listed: those pictures are the folder's, and they travel back with it. */
+async function measureLiveAssets(assetsDir: FileSystemDirectoryHandle): Promise<{ newest: number; size: number }> {
+    let newest = 0;
+    let size = 0;
+    try {
+        for await (const [name, handle] of assetsDir.entries()) {
+            // .DS_Store skipped the way every other walker here skips it: it is
+            // Finder's, not the reader's, and weighing it would put a folder's
+            // deletion time at whenever macOS last touched that file.
+            if (handle.kind !== 'file' || name === '.DS_Store') continue;
+            const stat = await statFile(handle);
+            newest = Math.max(newest, stat.mtime);
+            size += stat.size;
+        }
+    } catch (err) {
+        console.warn('Could not measure a trashed folder’s pictures:', err);
+    }
+    return { newest, size };
+}
+
+/** One trashed folder, and what drilling into it shows. Its deletion time is
+ *  the newest mtime anywhere inside it, which is when the copy was made. */
+async function buildTrashedDir(
+    dir: FileSystemDirectoryHandle,
+    path: string,
+    parentHandle: FileSystemDirectoryHandle,
+    ownerDir: FileSystemDirectoryHandle,
+    ownerPath: string,
+    out: TrashItem[],
+): Promise<TrashItem> {
+    const children: TrashItem[] = [];
+    let newest = 0;
+    let size = 0;
+
+    try {
+        for await (const [name, handle] of dir.entries()) {
+            if (name === '.DS_Store' || !isAssetName(name)) continue;
+            const childPath = joinVaultPath(path, name);
+
+            if (handle.kind === 'directory') {
+                if (name === TRASH_DIR) {
+                    // Deleted from this folder BEFORE the folder itself was, so
+                    // it was never part of what the reader threw away here.
+                    // Hoisted to the bin's root, where it reads as the
+                    // standalone deletion it was — and goes back to the owner,
+                    // not into this folder.
+                    await collectGarbage(handle, childPath, ownerDir, ownerPath, out);
+                    continue;
+                }
+                if (name === ASSETS_DIR) {
+                    const measured = await measureLiveAssets(handle);
+                    newest = Math.max(newest, measured.newest);
+                    size += measured.size;
+                    continue;
+                }
+                const sub = await buildTrashedDir(handle, childPath, dir, ownerDir, ownerPath, out);
+                newest = Math.max(newest, sub.deletedAt);
+                size += sub.size;
+                children.push(sub);
+                continue;
+            }
+
+            const stat = await statFile(handle);
+            newest = Math.max(newest, stat.mtime);
+            size += stat.size;
+            children.push({
+                id: childPath, name, kind: 'file', origin: 'trashed', sourcePath: childPath,
+                handle, parentHandle: dir,
+                restorePath: ownerPath, restoreDirHandle: ownerDir,
+                deletedAt: stat.mtime, size: stat.size,
+            });
+        }
+    } catch (err) {
+        console.warn('Could not read the trashed folder at', path, err);
+    }
+
+    return {
+        id: path, name: dir.name, kind: 'directory', origin: 'trashed', sourcePath: path,
+        handle: dir, parentHandle,
+        restorePath: ownerPath, restoreDirHandle: ownerDir,
+        deletedAt: newest, size,
+        children: sortTrashChildren(children),
+    };
+}
+
+/**
+ * The bin row for an entry a "Replace" has just displaced into `bucket`.
+ *
+ * Read back off disk rather than assembled from what was displaced: the copy
+ * is what the bin now holds, and its name is whatever `freeEntryName` settled
+ * on. Returns undefined if it cannot be read — the put-back itself succeeded,
+ * and the row will be there the next time the bin is opened (which re-crawls
+ * from scratch anyway).
+ */
+async function describeDisplaced(
+    bucket: FileSystemDirectoryHandle,
+    bucketPath: string,
+    name: string,
+    kind: 'file' | 'directory',
+    origin: TrashItem['origin'],
+    ownerDir: FileSystemDirectoryHandle,
+    ownerPath: string,
+): Promise<TrashItem | undefined> {
+    const sourcePath = joinVaultPath(bucketPath, name);
+    try {
+        if (kind === 'file') {
+            const handle = await bucket.getFileHandle(name);
+            const { mtime, size } = await statFile(handle);
+            return {
+                id: sourcePath, name, kind: 'file', origin, sourcePath,
+                handle, parentHandle: bucket,
+                restorePath: ownerPath, restoreDirHandle: ownerDir,
+                deletedAt: mtime || Date.now(), size,
+            };
+        }
+        const handle = await bucket.getDirectoryHandle(name);
+        // Any nested `.Garbage` this folder carries would be hoisted rows of
+        // their own; they are dropped rather than guessed at, and turn up on
+        // the bin's next open.
+        const hoisted: TrashItem[] = [];
+        return await buildTrashedDir(handle, sourcePath, bucket, ownerDir, ownerPath, hoisted);
+    } catch (err) {
+        console.warn('Could not describe the displaced entry at', sourcePath, err);
+        return undefined;
+    }
+}
+
+/** The live tree, looking for `.Garbage` folders. Never descends into one (that
+ *  is collectGarbage's job) and never into a live `.Assets`. */
+async function walkForTrash(dir: FileSystemDirectoryHandle, path: string, out: TrashItem[]): Promise<void> {
+    try {
+        for await (const [name, handle] of dir.entries()) {
+            if (handle.kind !== 'directory' || !isAssetName(name)) continue;
+            if (name === ASSETS_DIR) continue;             // live pictures, not trash
+            const childPath = joinVaultPath(path, name);
+            if (name === TRASH_DIR) {
+                await collectGarbage(handle, childPath, dir, path, out);
+                continue;
+            }
+            await walkForTrash(handle, childPath, out);
+        }
+    } catch (err) {
+        console.warn('Could not walk', path || 'the vault root', 'for trash:', err);
+    }
 }
 
 export function FileSystemProvider({ children }: { children: ReactNode }) {
@@ -919,21 +1262,11 @@ export function FileSystemProvider({ children }: { children: ReactNode }) {
      * lands in the trash is what the reader last had rather than what was last
      * autosaved.
      *
-     * IT EITHER HAPPENED OR IT DIDN'T. Anything that throws — a copy that dies
-     * partway, or a `removeEntry` refused because a file inside is still being
-     * written — takes the copy back out again before reporting failure. Without
-     * that, the realistic failure (the copy SUCCEEDS and the removal is refused)
-     * left a complete second copy of the folder in `.Garbage`, and every retry
-     * added another numbered one: megabytes to gigabytes of trash indexed under
-     * names indistinguishable, in Finder, from a good backup. Removing it is
-     * safe precisely because it is ours — `freeEntryName` certified the name
-     * free a moment earlier and nothing else may be trashing at the same time
-     * (App.handleTrash serializes) — so this can only unmake what it just made.
-     * It is not a licence to prune `.Garbage`, which nothing here does.
-     *
-     * The rollback can never run once the original is gone: `refreshTree`
-     * handles its own errors, so `removeEntry` succeeding is the last thing that
-     * can fail.
+     * IT EITHER HAPPENED OR IT DIDN'T — the copy is taken back out again on any
+     * failure, which is `displaceInto`'s doing and documented there. Its
+     * rollback can never run once the original is gone: `refreshTree` handles
+     * its own errors, so `removeEntry` succeeding is the last thing that can
+     * fail.
      */
     const moveToTrash = useCallback(async (node: FileTreeNode) => {
         if (!rootHandle || !node.parentHandle) return false;
@@ -945,27 +1278,9 @@ export function FileSystemProvider({ children }: { children: ReactNode }) {
         // copyDirRecursive walking into the copy it is making, without bound.
         if (node.kind === 'directory' && (node.name === TRASH_DIR || node.name === ASSETS_DIR)) return false;
 
-        // What this call has put into `.Garbage`, so a failure can take it back
-        // out. Recorded before a single byte is written, so a copy that dies
-        // on its first file is unmade just as surely as one that dies on its last.
-        let wrote: { dir: FileSystemDirectoryHandle; name: string } | null = null;
-
         try {
             const trashDir = await node.parentHandle.getDirectoryHandle(TRASH_DIR, { create: true });
-            // Deleting the same name twice must not destroy the first copy.
-            const trashName = await freeEntryName(trashDir, node.name, node.kind);
-            wrote = { dir: trashDir, name: trashName };
-
-            if (node.kind === 'file') {
-                await copyFileInto(trashDir, trashName, await node.handle.getFile());
-            } else {
-                const grave = await trashDir.getDirectoryHandle(trashName, { create: true });
-                await copyDirRecursive(node.handle, grave);
-            }
-
-            // Remove original. Recursively for a folder — it still holds
-            // everything that was just copied out of it.
-            await node.parentHandle.removeEntry(node.name, { recursive: node.kind === 'directory' });
+            await displaceInto(trashDir, node.parentHandle, node);
             // The pictures that folder held can only have been shown by notes
             // inside it (resolution never looks sideways or down), and those are
             // closed. A url that can never be displayed again is a pinned blob —
@@ -975,18 +1290,220 @@ export function FileSystemProvider({ children }: { children: ReactNode }) {
             return true;
         } catch (err) {
             console.error('Failed to move item to trash:', err);
-            if (wrote) {
-                try {
-                    await wrote.dir.removeEntry(wrote.name, { recursive: node.kind === 'directory' });
-                } catch (undoErr) {
-                    // Nothing is lost — the original is still there — so say so
-                    // and leave it rather than trying harder at a failing disk.
-                    console.error('Could not remove the abandoned trash copy:', undoErr);
-                }
-            }
             return false;
         }
     }, [rootHandle, refreshTree, revokeAssetUrlsUnder]);
+
+    /**
+     * Everything trashed anywhere in this vault, newest deletion first — the
+     * bin's root list. Built fresh on every call; see the crawl above for why
+     * there is deliberately no cache and what the flattening rules are.
+     */
+    const listTrash = useCallback(async (): Promise<TrashItem[]> => {
+        if (!rootHandle) return [];
+        const out: TrashItem[] = [];
+        await walkForTrash(rootHandle, '', out);
+        return sortTrashRoot(out);
+    }, [rootHandle]);
+
+    /**
+     * Put one item back where the `.Garbage` holding it sits — `item.restorePath`,
+     * which the crawl set to the parent of the OUTERMOST `.Garbage` on its path.
+     * A file three folders deep inside something that was deleted as a unit
+     * therefore comes back flat, beside that `.Garbage`, rather than under a
+     * recreation of an ancestry the reader no longer has.
+     *
+     * Structurally `moveToTrash` in reverse, and deliberately NOT `moveFile` /
+     * `renameFile`: those are the documented `freeEntryName` exceptions, so a
+     * file put back onto a taken name would silently truncate the live file and
+     * a folder would silently merge into the live one — neither with a rollback.
+     * Here a taken name is reported ('collision') with nothing touched, and
+     * answered by the caller.
+     *
+     * 'replace' DISPLACES rather than erases: the entry standing in the way is
+     * moved into that folder's own `.Garbage` first (a retired picture into its
+     * `.Garbage/.Assets`, which is where a retired picture lives) and handed
+     * back, so the bin can list it. Nothing the user made is destroyed outright
+     * — deleteFromTrash is the one call in here that does that, and only when
+     * asked in so many words.
+     */
+    const restoreFromTrash = useCallback(async (item: TrashItem, mode: TrashRestoreMode): Promise<TrashRestoreResult> => {
+        if (!rootHandle) return { status: 'error' };
+        // Mirrors moveToTrash's guard, and is unreachable for the same reason:
+        // the crawl lists neither hidden folder as an item. If it ever were
+        // reached, the failure is copyDirRecursive walking into its own copy.
+        if (!isAssetName(item.name)) return { status: 'error' };
+        if (item.kind === 'directory' && (item.name === TRASH_DIR || item.name === ASSETS_DIR)) return { status: 'error' };
+
+        // What this call has written at the destination, so a failure can take
+        // it back out — the same record-before-the-first-byte rule displaceInto
+        // keeps, for the same reason.
+        let wrote: { dir: FileSystemDirectoryHandle; name: string } | null = null;
+
+        try {
+            const home = item.restoreDirHandle;
+            // A retired picture goes back into `.Assets`. Probed rather than
+            // created, cheapest miss first (restoreAsset's shape): a folder with
+            // no `.Assets` at all cannot have a colliding name, and creating one
+            // here would leave an empty folder behind if the reader then
+            // cancelled at the collision question.
+            let destDir: FileSystemDirectoryHandle | null = home;
+            if (item.origin === 'retired') {
+                try {
+                    destDir = await home.getDirectoryHandle(ASSETS_DIR);
+                } catch {
+                    destDir = null;
+                }
+            }
+
+            const taken = destDir ? await entryExists(destDir, item.name) : false;
+            if (taken && mode === 'auto') return { status: 'collision' };
+
+            let displaced: TrashItem | undefined;
+            if (taken && destDir && mode === 'replace') {
+                const live = await liveEntry(destDir, item.name);
+                if (!live) return { status: 'error' };
+                // A displaced picture is a RETIRED picture: it belongs in the
+                // bucket retireAsset uses, not beside the trashed notes, or
+                // putting it back later would land it outside `.Assets`.
+                const bucket = item.origin === 'retired'
+                    ? await retiredAssetsDir(home, true)
+                    : await destDir.getDirectoryHandle(TRASH_DIR, { create: true });
+                const bucketPath = item.origin === 'retired'
+                    ? joinVaultPath(joinVaultPath(item.restorePath, TRASH_DIR), ASSETS_DIR)
+                    : joinVaultPath(item.restorePath, TRASH_DIR);
+                const filedAs = await displaceInto(bucket, destDir, live);
+                // Same reason moveToTrash revokes: the pictures a displaced
+                // FOLDER held can only have been shown by notes inside it, and
+                // App has just closed those — a url nothing can display again is
+                // a pinned blob.
+                if (live.kind === 'directory') revokeAssetUrlsUnder(joinVaultPath(item.restorePath, item.name));
+                displaced = await describeDisplaced(
+                    bucket, bucketPath, filedAs, live.kind, item.origin, home, item.restorePath);
+            }
+
+            const finalName = taken && destDir && mode === 'keep-both'
+                ? await freeEntryName(destDir, item.name, item.kind)
+                : item.name;
+
+            // Only now is there anything to restore, and only now is creating
+            // the folder's `.Assets` warranted.
+            if (!destDir) {
+                destDir = await home.getDirectoryHandle(ASSETS_DIR, { create: true });
+                // The probe above read a MISSING `.Assets` as "no collision is
+                // possible", which is the one path here where a name was never
+                // certified free — and if the create-lookup hands back a folder
+                // that does exist after all (the no-create read failed for some
+                // other reason, or something outside this tab made it in the
+                // meantime), copyFileInto's `getFileHandle(create: true)` would
+                // open-or-TRUNCATE whatever is standing there. Ask again now
+                // that the real directory is in hand.
+                if (await entryExists(destDir, finalName)) return { status: 'collision' };
+            }
+
+            wrote = { dir: destDir, name: finalName };
+            if (item.kind === 'file') {
+                await copyFileInto(destDir, finalName, await (item.handle as FileSystemFileHandle).getFile());
+            } else {
+                const copy = await destDir.getDirectoryHandle(finalName, { create: true });
+                await copyDirRecursive(item.handle as FileSystemDirectoryHandle, copy);
+            }
+
+            await item.parentHandle.removeEntry(item.name, { recursive: item.kind === 'directory' });
+            await refreshTree(rootHandle);
+            return { status: 'ok', name: finalName, displaced };
+        } catch (err) {
+            console.error('Failed to put the item back:', err);
+            if (wrote) {
+                try {
+                    await wrote.dir.removeEntry(wrote.name, { recursive: item.kind === 'directory' });
+                } catch (undoErr) {
+                    console.error('Could not remove the abandoned restored copy:', undoErr);
+                }
+            }
+            // A 'replace' that displaced something and THEN failed to copy
+            // leaves that entry in the trash rather than putting it back: it is
+            // one more row in the bin, one click from home, which is a better
+            // failure than a second copy-and-delete run to undo the first while
+            // the disk is already refusing writes. Nothing is lost either way.
+            return { status: 'error' };
+        }
+    }, [rootHandle, refreshTree, revokeAssetUrlsUnder]);
+
+    /**
+     * Erase one item from the trash for good. With `emptyTrash`, the only thing
+     * in this app that destroys something the user made with no copy left
+     * anywhere — which is why both are behind a question App words plainly.
+     *
+     * No `refreshTree`: nothing inside a `.Garbage` is in the file tree.
+     */
+    const deleteFromTrash = useCallback(async (item: TrashItem) => {
+        if (!isAssetName(item.name)) return false;
+        // The same refusal restoreFromTrash keeps, and it belongs here more than
+        // there: this one is `removeEntry(..., { recursive: true })`, so an item
+        // that ever leaked a `.Garbage`/`.Assets` name would erase a whole
+        // bucket rather than the thing the reader pointed at. Unreachable today
+        // — the crawl diverts both names before it builds an item.
+        if (item.kind === 'directory' && (item.name === TRASH_DIR || item.name === ASSETS_DIR)) return false;
+        try {
+            await item.parentHandle.removeEntry(item.name, { recursive: item.kind === 'directory' });
+            return true;
+        } catch (err) {
+            console.error('Failed to delete the item for good:', err);
+            return false;
+        }
+    }, []);
+
+    /**
+     * Remove every `.Garbage` in the vault, retired pictures and all. Returns
+     * how many folders were removed AND how many refused.
+     *
+     * Each removal is its own try/catch, so one folder held open by something
+     * else does not cost the reader the rest of the emptying — and the names
+     * are collected before anything is removed, because removing entries while
+     * an `entries()` iterator is walking them is not something the API
+     * promises anything about. `failed` is what keeps that tolerance honest: a
+     * caller that saw only the count would empty the panel's list and say the
+     * bin was emptied while the folders that refused still held their files.
+     */
+    const emptyTrash = useCallback(async () => {
+        if (!rootHandle) return { removed: 0, failed: 0 };
+        let removed = 0;
+        let failed = 0;
+
+        const sweep = async (dir: FileSystemDirectoryHandle): Promise<void> => {
+            const live: FileSystemDirectoryHandle[] = [];
+            let hasTrash = false;
+            try {
+                for await (const [name, handle] of dir.entries()) {
+                    if (handle.kind !== 'directory' || !isAssetName(name)) continue;
+                    if (name === ASSETS_DIR) continue;
+                    if (name === TRASH_DIR) { hasTrash = true; continue; }
+                    live.push(handle);
+                }
+            } catch (err) {
+                console.warn('Could not read a folder while emptying the trash:', err);
+                // Unread, so unknown: counted as a failure rather than passed
+                // over, since a `.Garbage` it holds is still on disk either way.
+                failed++;
+                return;
+            }
+
+            if (hasTrash) {
+                try {
+                    await dir.removeEntry(TRASH_DIR, { recursive: true });
+                    removed++;
+                } catch (err) {
+                    console.error('Could not empty the trash in', dir.name, err);
+                    failed++;
+                }
+            }
+            for (const sub of live) await sweep(sub);
+        };
+
+        await sweep(rootHandle);
+        return { removed, failed };
+    }, [rootHandle]);
 
     /**
      * Move a file from its current parent to a target directory handle.
@@ -1083,6 +1600,10 @@ export function FileSystemProvider({ children }: { children: ReactNode }) {
         restoreAsset,
         restoreVault,
         moveToTrash,
+        listTrash,
+        restoreFromTrash,
+        deleteFromTrash,
+        emptyTrash,
         moveFile,
         renameFile,
     };

--- a/src/index.css
+++ b/src/index.css
@@ -658,7 +658,14 @@ body {
   background: linear-gradient(to right, transparent, var(--tree-row-bg) 16px);
 }
 
-.tree-item:hover .tree-item-actions {
+/* …and whenever the keyboard is on one of them. Without the second selector the
+   buttons keep `opacity: 0` while focused — which fades the focus ring too — so
+   tabbing through a list moved focus onto invisible controls and Enter fired
+   whichever one it happened to be sitting on. That is a nuisance in the file
+   tree and worse in the Trash panel, whose rows put Delete permanently, the
+   app's one irreversible action, second in the tab order. */
+.tree-item:hover .tree-item-actions,
+.tree-item:focus-within .tree-item-actions {
   opacity: 1;
 }
 
@@ -676,9 +683,33 @@ body {
   transition: color 0.12s, background 0.12s;
 }
 
-.tree-action-btn:hover {
+.tree-action-btn:hover:not(:disabled) {
   color: var(--text-normal);
   background: var(--background-modifier-hover);
+}
+
+/* Nothing in the file tree ever disables one of these; the Trash panel's rows
+   do while an operation is in flight, and so does the sidebar's bin with no
+   vault open. A control that cannot act must not light up under the pointer —
+   the same `:not(:disabled)` treatment .context-menu-item gets. */
+.tree-action-btn:disabled {
+  color: var(--text-faint);
+  cursor: default;
+}
+
+/* TreeNode has been putting this class on its Move-to-Trash buttons with
+   nothing in this file to answer it — the modifier existed only in the markup.
+   Same red as .context-menu-item.is-danger, which already paints that very
+   command in the right-click menu, so the app keeps ONE colour for "this
+   destroys something" and the Trash panel's Delete-permanently button reuses
+   this rather than inventing a second danger class.
+
+   Hover only, never at rest: a row of icon buttons that is red before you reach
+   it reads as an error state, and the context menu's rows carry a label to
+   justify their standing colour where a bare 13px glyph does not. */
+.trash-btn:hover:not(:disabled) {
+  color: #e06c75;
+  background: rgba(224, 108, 117, 0.12);
 }
 
 /* Inline rename/create input */
@@ -1329,6 +1360,41 @@ body.is-resizing-panes * {
   flex-shrink: 0;
 }
 
+/* ── The Settings row, which is the only one that carries a second button ──
+   Search, Neural Brain and Help Guide above it are still bare .theme-toggle-btn
+   children of the container and are deliberately left that way: one row gained
+   the bin, not the group.
+
+   flex:1 is not tidiness. .theme-toggle-btn is `width: 100%`, which as a flex
+   item becomes its flex BASIS, so the labelled button asks for the whole row on
+   its own and the bin is fitted only by shrinking it — and a flex item's
+   `min-width: auto` is its content width, a floor the label cannot go under.
+   At the 180px sidebar minimum (the resize clamp) that leaves the row 152px
+   against a 28px bin, so the two would fight instead of sharing. Basis 0 plus
+   min-width 0 makes the label take what is left over instead. */
+.sidebar-bottom-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sidebar-bottom-row .theme-toggle-btn {
+  flex: 1;
+  min-width: 0;
+}
+
+/* 28px, not .tree-action-btn's 22. It has to read as the same object as the
+   labelled button beside it, and that button is 6px + a 16px glyph + 6px = 28px
+   tall (its `padding: 6px 8px` against a 16px icon, which out-measures the 13px
+   label's line box). A 28px square puts exactly that same 6px around exactly
+   that same 16px glyph; 22px would sit 3px short of the row and hover would
+   light a chip visibly smaller than its neighbour's. */
+.sidebar-trash-btn {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+}
+
 /* ── Settings Panel Overlay ── */
 .settings-overlay {
   position: fixed;
@@ -1757,6 +1823,307 @@ body.is-resizing-panes * {
 .settings-reset-btn:hover {
   background: var(--interactive-accent);
   color: #fff;
+}
+
+/* =============================================================
+   Trash panel (components/TrashPanel.tsx)
+   Everything in every folder's .Garbage, in one modal: a list on the left, a
+   read-only preview on the right.
+   ============================================================= */
+
+/* .settings-overlay, MINUS the blur — and that omission is the requirement, not
+   an oversight to be tidied back into line with Settings. The point of this
+   panel is deciding whether a file is the one you meant to lose, and the vault
+   behind it is the only context for that: dimmed so the modal reads as raised,
+   still legible so the tree row you deleted from is still there. */
+.trash-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  /* Settings' band: the two are peers and never open together. Below
+     ConfirmDialog's 1100, which matters here more than it does for Settings —
+     Delete permanently and Empty bin both raise a question, and the question
+     has to cover the panel that asked it. */
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* .settings-panel's surface, but a DEFINITE height rather than a max: the list
+   and the preview scroll independently, and `max-height` would let the box
+   shrink to whichever pane happened to be shorter — so the panel would resize
+   under the pointer as rows are put back or deleted.
+
+   No light-theme override, unlike .vault-menu and .context-menu. Those two are
+   raised over the sidebar, where --background-primary-alt IS the sidebar's own
+   #f2f3f5 and the surface disappears. This floats centred over the editor and
+   over a 50%-black scrim, so the same value reads as a lit sheet in both
+   themes. Adding one here would only make it brighter than it needs to be. */
+.trash-panel {
+  width: min(900px, 92vw);
+  height: min(78vh, 680px);
+  background: var(--background-primary-alt);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.trash-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.trash-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-normal);
+}
+
+/* The × is .settings-close-btn itself, not a clone of it. */
+
+.trash-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+/* The list gets the larger half. Measured at 42%: a row's three fixed items —
+   the 22px icon, the origin folder, and a timestamp reserving 62px of clearance
+   for the hover buttons — left a 37-character name 32px to render in at a
+   1400px window, and nothing at all below 800px, where the row then overflowed
+   its own pane. The name is what the reader is scanning for; the preview pane
+   answers one question and can afford the narrower side. */
+.trash-list-pane {
+  flex: 0 0 58%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--background-modifier-border);
+}
+
+.trash-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.trash-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.trash-list::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb-bg);
+  border-radius: 4px;
+}
+
+.trash-preview-pane {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  padding: 14px 16px;
+}
+
+/* Rows compose .tree-item, so they arrive with its fixed height and its
+   content-visibility box — a vault that has been used for a year can have
+   thousands of these too.
+
+   RESTATING --tree-row-bg IS THE LOAD-BEARING LINE. .tree-item-actions fades
+   into `var(--tree-row-bg)`, whose default is --background-secondary: the
+   SIDEBAR's colour. Left alone, the hover buttons in this panel would sit on a
+   strip of the file tree's grey over the modal's lighter surface. Each state
+   below restates it for the same reason the tree's own states do. */
+.trash-row {
+  --tree-row-bg: var(--background-primary-alt);
+  padding-left: 10px;
+  color: var(--text-normal);
+}
+
+.trash-row:hover {
+  background: var(--background-modifier-hover);
+  --tree-row-bg: var(--background-modifier-hover);
+}
+
+/* After :hover, so the row being previewed keeps saying so while the pointer is
+   over it — the same ordering .tree-item.is-active relies on. */
+.trash-row.is-selected {
+  background: var(--background-modifier-active);
+  --tree-row-bg: var(--background-modifier-active);
+}
+
+/* Keyboard focus on a row, the same treatment SearchPanel's result rows get —
+   these are `role="button"` `tabIndex={0}` rows and the whole panel is
+   keyboard-reachable, so the UA's own ring on a row that paints its own
+   backgrounds is not enough to see. */
+.trash-row:focus-visible {
+  outline: 1px solid var(--interactive-accent);
+  outline-offset: -1px;
+}
+
+/* Takes the row's spare width, and yields it LAST. Without the grow it sat at
+   its content width and was the only item that could shrink, so every shortfall
+   came out of the one column that identifies the file. */
+.trash-row-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Where it was deleted from. Capped AND allowed to shrink: the cap stops a deep
+   origin folder from eating the name at a comfortable width, and the shrink is
+   what keeps the row inside its pane in a narrow window instead of overflowing
+   it — an ellipsized folder is still a recognizable one. */
+.trash-row-dir {
+  margin-left: 6px;
+  max-width: 40%;
+  flex-shrink: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+/* Right-aligned, but held 62px clear of the row's right edge, and that number
+   is measured off .tree-item-actions rather than chosen: the actions float at
+   `right: 8px` — the row's own padding — over two 22px buttons with a 2px gap
+   (46px), behind a 16px fade. 62px is where that gradient is still fully
+   transparent, so the timestamp is untouched on hover instead of dissolving
+   under the buttons that appear on top of it. Re-derive it if the row ever
+   gains or loses an action. */
+.trash-row-time {
+  /* A real gap, not `margin-left: auto`: the name grows into the row's spare
+     width now, so there is none left for an auto margin to take and the folder
+     and the date rendered flush against each other. */
+  margin-left: 10px;
+  padding-right: 62px;
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+.trash-breadcrumb {
+  padding: 8px 12px 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.trash-crumb {
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.trash-crumb:hover {
+  text-decoration: underline;
+}
+
+/* The house empty state, same as .search-hint. */
+.trash-empty {
+  margin: 0;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+/* The same line inside the preview pane, which already carries the padding —
+   so this one takes none. Sharing .trash-empty's `padding: 10px 12px` indented
+   every preview line 12px past the title above it and turned the title's 8px
+   gap into 18px. */
+.trash-preview-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+/* "No preview for this kind of file." and the size-and-date line under it are
+   two of these in a row, and with the padding gone they would be flush. */
+.trash-preview-empty + .trash-preview-empty {
+  margin-top: 4px;
+}
+
+.trash-preview-title {
+  margin: 0 0 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* Deliberately monospace and pre-wrap: this is the file as it is ON DISK, not a
+   rendered note. Nothing here is an editor, so markdown must not look like one.
+   overflow-wrap is what keeps a minified line or a long URL inside the pane. */
+.trash-preview-text {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  font-family: var(--font-monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-normal);
+}
+
+.trash-preview-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.trash-footer {
+  display: flex;
+  align-items: center;
+  padding: 10px 16px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+/* .confirm-btn's shape wearing the app's one destructive red (.trash-btn,
+   .context-menu-item.is-danger). The only control in the app that deletes
+   without a copy surviving somewhere, so the red is at rest and not only on
+   hover — unlike the row buttons, this one is read before it is reached. */
+.trash-empty-btn {
+  padding: 7px 16px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-secondary);
+  color: #e06c75;
+  font-size: 13px;
+  font-family: var(--font-text);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.trash-empty-btn:hover {
+  background: rgba(224, 108, 117, 0.12);
+  border-color: rgba(224, 108, 117, 0.35);
+}
+
+.trash-empty-btn:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
+}
+
+/* An empty bin cannot be emptied. The :hover half is not redundant — a disabled
+   button still matches :hover, so without it the rule above would light up a
+   red box under a pointer that cannot do anything with it. */
+.trash-empty-btn:disabled,
+.trash-empty-btn:disabled:hover {
+  background: var(--background-secondary);
+  border-color: var(--background-modifier-border);
+  color: var(--text-faint);
+  cursor: default;
 }
 
 /* ── Empty state ── */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -249,6 +249,62 @@ export interface RecentVault extends StoredVault {
 export type VaultOpenResult = 'ok' | 'denied' | 'missing' | 'error' | 'busy';
 
 /* ─────────────────────────────────────────────────────────────────────────
+ * TRASH
+ * What the bin's crawl of every `.Garbage` in the vault produces. Built FRESH
+ * on every open of the bin — nothing about the trash is written down, cached or
+ * carried between openings, because a deletion's only record is the copy itself
+ * sitting in the `.Garbage` beside where it came from. FileSystemContext's
+ * `walkForTrash` and the banner above it hold the listing and path rules;
+ * utils/trash.ts holds what the list does afterwards (order, pruning, formats).
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/** One restorable thing found by the `.Garbage` crawl. */
+export interface TrashItem {
+  /** Unique within one crawl, and the React key: the source path. */
+  id: string;
+  name: string;
+  kind: 'file' | 'directory';
+  /**
+   * 'retired' = an image the app moved out of `.Assets` by itself once the last
+   * note stopped embedding it (see retireAsset). It goes back INTO `.Assets`,
+   * not beside it: an embed only ever resolves from there, so a retired picture
+   * put back alongside the notes would be a file nothing could display.
+   */
+  origin: 'trashed' | 'retired';
+  /** Vault-relative path of the copy on disk, `.Garbage` segments and all. */
+  sourcePath: string;
+  handle: FileSystemFileHandle | FileSystemDirectoryHandle;
+  /** The directory on disk holding it — what `removeEntry` is called on. */
+  parentHandle: FileSystemDirectoryHandle;
+  /** Vault-relative path of the folder a put-back lands in: the parent of the
+   *  OUTERMOST `.Garbage` on `sourcePath`. '' is the vault root. */
+  restorePath: string;
+  restoreDirHandle: FileSystemDirectoryHandle;
+  /** ms epoch — the newest `lastModified` in this item's subtree, which is when
+   *  the copy was made, i.e. when it was deleted. 0 if nothing was readable. */
+  deletedAt: number;
+  /** Bytes. For a folder, the total of what it holds — its own `.Assets`
+   *  included, its nested `.Garbage` excluded (that is listed separately). */
+  size: number;
+  /** Directories only: what drilling into it shows. Dot-folders are never in
+   *  here — see `buildTrashedDir` in FileSystemContext. */
+  children?: TrashItem[];
+}
+
+/** How a put-back should deal with a destination name that is already taken.
+ *  'auto' = don't: report the collision and let the user decide. */
+export type TrashRestoreMode = 'auto' | 'replace' | 'keep-both';
+
+/** What a put-back did. 'collision' means NOTHING was touched — the name is
+ *  taken and the mode was 'auto'. `displaced` is the live entry a 'replace'
+ *  moved into that folder's own `.Garbage` (never erased), so the bin can list
+ *  it as the newest thing in the trash. */
+export type TrashRestoreResult =
+  | { status: 'ok'; name: string; displaced?: TrashItem }
+  | { status: 'collision' }
+  | { status: 'error' };
+
+/* ─────────────────────────────────────────────────────────────────────────
  * SETTINGS
  * The DEFAULTS object is the canonical shape (SettingsPanel.jsx:3) and is what
  * onResetDefaults receives (App.jsx:138 handleResetDefaults). Each field also
@@ -339,6 +395,22 @@ export interface FileSystemContextValue {
   restoreAsset: (fileName: string, dirHandle: FileSystemDirectoryHandle) => Promise<boolean>;
   restoreVault: () => Promise<void>;                     // :241
   moveToTrash: (node: FileTreeNode) => Promise<boolean>; // :260
+  /** Crawl every `.Garbage` in the vault and return the bin's flat root list,
+   *  newest-deleted first. Uncached by design — see the crawl's own comment. */
+  listTrash: () => Promise<TrashItem[]>;
+  /** Put one item back beside the `.Garbage` it was found in. Never overwrites
+   *  without being told to; 'replace' moves the entry it displaces into that
+   *  folder's own `.Garbage` rather than erasing it, and hands it back so the
+   *  bin can list it. */
+  restoreFromTrash: (item: TrashItem, mode: TrashRestoreMode) => Promise<TrashRestoreResult>;
+  /** Erase one item from `.Garbage` for good — one of only two calls in the app
+   *  that destroy something the user made with no copy surviving. */
+  deleteFromTrash: (item: TrashItem) => Promise<boolean>;
+  /** Remove every `.Garbage` in the vault. Each removal stands alone, so one
+   *  folder something else is holding open does not cost the rest: `failed`
+   *  counts those, and a caller that ignores it would tell the reader the bin
+   *  was emptied while trash was still on disk. */
+  emptyTrash: () => Promise<{ removed: number; failed: number }>;
   moveFile: (sourceNode: FileTreeNode, targetDirHandle: FileSystemDirectoryHandle) => Promise<boolean>; // :297
   renameFile: (sourceNode: FileTreeNode, newName: string) => Promise<boolean>; // :329
 }

--- a/src/utils/fileTypes.ts
+++ b/src/utils/fileTypes.ts
@@ -36,6 +36,17 @@ export function ensureNotebookExt(name: string): string {
     return isNotebookFile(name) ? name : `${name}${NOTEBOOK_EXT}`;
 }
 
+/**
+ * An image a plain `<img>` can show — what the trash bin previews inline.
+ *
+ * Deliberately narrower than "not text": a PDF is not text either, and
+ * previewing one would mean pulling pdf.js into the main bundle (see
+ * components/prefetchPanes.ts for why that split is load-bearing).
+ */
+export function isImageFile(name: string): boolean {
+    return /\.(png|jpe?g|gif|webp|bmp|avif|svg)$/i.test(name);
+}
+
 /* ── PDFs ────────────────────────────────────────────────────────────────
  * A PDF opens in a pane with two modes: View (the real PDF — scrollable,
  * text selectable) and Annotate (a tldraw canvas over rasterized pages).

--- a/src/utils/helpDoc.ts
+++ b/src/utils/helpDoc.ts
@@ -81,7 +81,8 @@ so the list you switch vaults with looks like the tree you set up.
 
 ### Searching the Vault
 **Search** sits at the bottom of the sidebar, under the theme switch, alongside
-Neural Brain and Settings. It looks through every note in the vault — file names
+Neural Brain, Help Guide and Settings — with the Trash bin's icon at the
+right-hand end of the Settings row. It looks through every note in the vault — file names
 *and* the text inside them — and replaces the file tree while it is open. Picking
 a result opens that note and scrolls to the line it matched, then puts the tree
 back. Notebooks, drawings and PDFs match on their names only, since what is in
@@ -302,15 +303,32 @@ Deleting a picture — with the bin, with \`Backspace\`, or just by deleting the
 Nothing is lost by this:
 - An image another note **in the same folder** still shows is left exactly where it is.
 - Undo (\`Cmd + Z\` / \`Ctrl + Z\`) brings the picture back — the image file comes back out of \`.Garbage\` with it.
-- And anything that was retired is still sitting in \`.Garbage\`, recoverable by hand.
+- And anything that was retired is still sitting in \`.Garbage\`: it is listed in the Trash bin like anything else, and putting it back returns it to \`.Assets\`, where your notes can show it again.
 
 ### Opening Media
 If you click on \`.pdf\`, \`.jpg\`, \`.jpeg\`, or \`.png\` files directly within the file tree, they will automatically open in a new browser tab for viewing rather than attempting to load as text.
 
 ### The Trash System
-To prevent accidental permanent data loss, deleting a file does not erase it from your hard drive. Instead, it moves the item into a hidden \`.Garbage\` folder located in the same directory as the file — deleting \`Maths/Calculus/notes.md\` puts it in \`Maths/Calculus/.Garbage\`, so a deletion stays next to the notes it came from. Deleting the same name twice keeps both copies (the second becomes \`notes (1).md\`). You can manually recover these files using your computer's native file explorer (Finder or Windows Explorer) if needed.
+To prevent accidental permanent data loss, deleting a file does not erase it from your hard drive. Instead, it moves the item into a hidden \`.Garbage\` folder located in the same directory as the file — deleting \`Maths/Calculus/notes.md\` puts it in \`Maths/Calculus/.Garbage\`, so a deletion stays next to the notes it came from. Deleting the same name twice keeps both copies (the second becomes \`notes (1).md\`).
 
-Deleting a **folder** works exactly the same way, and takes everything inside it along: deleting \`Maths/Calculus\` puts the whole folder in \`Maths/.Garbage/Calculus\`, with its notes, its sub-folders and the pictures from its own \`.Assets\` still in place — so in most cases you can drag it back out in Finder and it works again just as it did. (A picture stored higher up the vault, from an older version of the app, stays where it is and is not copied along.) Any notes from that folder you had open are saved first and then closed, so nothing you had just typed is left behind. A large folder takes a moment to copy; the top bar says so while it does.
+Deleting a **folder** works exactly the same way, and takes everything inside it along: deleting \`Maths/Calculus\` puts the whole folder in \`Maths/.Garbage/Calculus\`, with its notes, its sub-folders and the pictures from its own \`.Assets\` still in place — so a recovered folder works again just as it did. (A picture stored higher up the vault, from an older version of the app, stays where it is and is not copied along.) Any notes from that folder you had open are saved first and then closed, so nothing you had just typed is left behind. A large folder takes a moment to copy; the top bar says so while it does.
+
+### The Trash Bin
+The **bin icon** at the bottom of the sidebar, at the right-hand end of the Settings row, shows everything you have deleted in the vault you have open — without your going near Finder or Windows Explorer.
+
+Opening it looks through every \`.Garbage\` folder in the vault, from the root down. Nothing about your trash is written down or remembered between openings, so what you see is always what is actually on disk — and a big vault takes a moment to look through. The window says so while it works.
+
+**What you see.** One list of everything trashed anywhere in the vault, newest deletion first, each row naming the folder it came out of (which is where it goes back to) and when it went. A deleted **folder** is a single row: click it to look inside, and use the trail at the top to come back out. Anything you deleted from that folder *before* you deleted the folder itself is listed on its own at the top level instead of inside it — it was a separate deletion, so it is offered back separately. Clicking a note shows it read-only beside the list, which is how you tell \`notes.md\` from \`notes (1).md\` before putting either back. Notebooks, drawings and PDFs are listed with their size and date but not drawn.
+
+**Put back** (the arrow on a row) returns an item to the folder holding the \`.Garbage\` it was found in. It does not rebuild the folders it used to live in: a note from four levels inside a folder you deleted comes back beside that folder's old home, not under a recreation of an ancestry you no longer have. Put back a single note out of a deleted folder and only that note leaves the bin — the rest of the folder stays there. A picture the app retired for you goes back into \`.Assets\`, where your notes can show it again.
+
+If something of that name is already there, you are asked: **Replace**, **Keep both**, or leave it. Replacing does not erase what is there now — it moves it into that folder's own \`.Garbage\`, where it appears at the top of this list. Keeping both puts yours back under a numbered name, and the top bar tells you which.
+
+One thing does not come back: an icon or colour you had given a file or folder is forgotten when you delete it, so a restored item looks like any other.
+
+**Delete permanently** (the bin on a row) and **Empty bin** (bottom left) are the only two things in this application that actually erase anything. Empty bin removes every \`.Garbage\` folder in the vault at once, retired pictures included. Both ask first, and neither can be undone.
+
+**Escape** closes the window, and so does clicking the dimmed area around it. If you would rather dig a file out by hand, you still can: every \`.Garbage\` is an ordinary folder sitting beside what it holds, so Finder or Windows Explorer reaches it too.
 
 ---
 

--- a/src/utils/trash.ts
+++ b/src/utils/trash.ts
@@ -1,0 +1,83 @@
+// What the bin's list does once the crawl has built it — ordering, pruning a
+// row that has left, and the two formats the rows print. Pure: no File System
+// Access calls live here (those are FileSystemContext's, per AGENTS.md).
+//
+// The pruning is what lets an operation NOT re-crawl: the panel is told an
+// item's `sourcePath` has gone and keeps its own list honest from that alone,
+// rather than walking every `.Garbage` in the vault again to learn it.
+
+import type { TrashItem } from '../types';
+
+/**
+ * The list with `sourcePath` — and everything under it — gone, at every depth.
+ *
+ * Restoring or erasing a trashed FOLDER takes its nested `.Garbage` with it,
+ * and the crawl hoisted every one of those rows to the bin root, so they are
+ * dangling the moment the folder moves. Same `path/` prefix rule the tab
+ * handlers use, for the same reason: `notes` must not match `notesolder`.
+ *
+ * Returns the array it was given when nothing matched, so an operation that
+ * touched nothing does not re-render the list.
+ */
+export function dropTrashSubtree(items: TrashItem[], sourcePath: string): TrashItem[] {
+    const prefix = `${sourcePath}/`;
+    let changed = false;
+    const kept: TrashItem[] = [];
+
+    for (const item of items) {
+        if (item.sourcePath === sourcePath || item.sourcePath.startsWith(prefix)) {
+            changed = true;
+            continue;
+        }
+        if (item.children) {
+            const children = dropTrashSubtree(item.children, sourcePath);
+            if (children !== item.children) {
+                changed = true;
+                kept.push({ ...item, children });
+                continue;
+            }
+        }
+        kept.push(item);
+    }
+
+    return changed ? kept : items;
+}
+
+/** The bin's root list: newest deletion first, ties broken by name. */
+export function sortTrashRoot(items: TrashItem[]): TrashItem[] {
+    return [...items].sort((a, b) =>
+        b.deletedAt - a.deletedAt ||
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+}
+
+/** What one trashed folder shows when you open it: folders first, then files,
+ *  alphabetical within each — buildFileTree's order. Deliberately NOT by time:
+ *  everything inside a folder was copied by the one deletion, so their times
+ *  differ only by how long the copy took. */
+export function sortTrashChildren(items: TrashItem[]): TrashItem[] {
+    return [...items].sort((a, b) => {
+        if (a.kind !== b.kind) return a.kind === 'directory' ? -1 : 1;
+        return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    });
+}
+
+const DELETED_AT_FORMAT = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+
+/** When it was deleted, for the row. Empty for 0 — nothing in the item was
+ *  readable, and a made-up "1 Jan 1970" would be worse than saying nothing. */
+export function formatDeletedAt(ms: number): string {
+    if (!ms) return '';
+    try {
+        return DELETED_AT_FORMAT.format(ms);
+    } catch {
+        return '';
+    }
+}
+
+/** A size for the preview pane. Rounded hard: this is the "which of these two
+ *  notes.md is mine" glance, not an accounting of the disk. */
+export function formatTrashSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} byte${bytes === 1 ? '' : 's'}`;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}


### PR DESCRIPTION
Trash has been scattered and invisible: every folder keeps its own .Garbage, so recovering a note meant knowing which folder it was deleted from and digging it out in Finder.

An unlabelled bin at the end of the Settings row now opens a panel that crawls every .Garbage in the vault and lists what it finds — flat, newest first, each row naming the folder it came from. Nothing is written to disk to support this: the crawl runs fresh on every open and each item's put-back destination is derived from its path, so it works whichever folder was opened as the vault.

Put back returns an item to the parent of the OUTERMOST .Garbage on its path, flat, with no ancestry recreated — so a note three levels inside a trashed folder lands beside that folder's original home, exactly where its deletion started. A retired picture goes back into .Assets instead, the reverse of how it got retired. A name collision asks: Replace, Keep both, or Cancel, and Replace displaces the live file into the trash rather than erasing it, so a put-back can never destroy anything either.

A folder's own .Assets travels back with it and is never listed; a nested .Garbage is hoisted to the root list, since what was deleted before its parent was deleted separately.

Delete permanently and Empty bin are there too, both behind confirmations — the only places in the app that remove a user's file outright.